### PR TITLE
FIX PiraeusN external network name

### DIFF
--- a/fiware-region-sanity-tests/resources/settings.json
+++ b/fiware-region-sanity-tests/resources/settings.json
@@ -16,7 +16,7 @@
             "Berlin": "ext-net-federation",
             "Prague": "default",
             "Mexico": "ext-net",
-            "PiraeusN": "Public",
+            "PiraeusN": "public-ext-net-1",
             "PiraeusU": "public-ext-net-1",
             "Zurich": "net04-ext",
             "Karlskrona": "PUBLIC3_external",


### PR DESCRIPTION
#### Reviewers

@flopezag 
#### Description

Change Neuropublic (PiraeusN) external network name
