### PR TITLE
fix: dev: Change the name of the PiraeusU, Gent and Zürich public network @minor

### DIFF
--- a/fiware-region-sanity-tests/README.rst
+++ b/fiware-region-sanity-tests/README.rst
@@ -136,15 +136,15 @@ All configuration values will be 'strings'.
                 "Prague": "default",
                 "Mexico": "ext-net",
                 "PiraeusN": "public-ext-net-01",
-                "PiraeusU": "public-ext-net-1",
-                "Zurich": "public-ext-net-1",
+                "PiraeusU": "public-ext-net-01",
+                "Zurich": "public-ext-net-01",
                 "Karlskrona": "public-ext-net-01",
                 "Volos": "public-ext-net-01",
                 "Budapest": "publicRange",
                 "Stockholm": "public-ext-net-01",
                 "SophiaAntipolis": "net04_ext",
                 "Poznan": "public_L3_v4",
-                "Gent": "Public-Net",
+                "Gent": "public-ext-net-03",
                 "Crete": "net04_ext"
             }
         },

--- a/fiware-region-sanity-tests/resources/settings.json
+++ b/fiware-region-sanity-tests/resources/settings.json
@@ -18,15 +18,15 @@
             "Prague": "default",
             "Mexico": "ext-net",
             "PiraeusN": "public-ext-net-01",
-            "PiraeusU": "public-ext-net-1",
-            "Zurich": "public-ext-net-1",
+            "PiraeusU": "public-ext-net-01",
+            "Zurich": "public-ext-net-01",
             "Karlskrona": "public-ext-net-01",
             "Volos": "public-ext-net-01",
             "Budapest": "publicRange",
             "Stockholm": "public-ext-net-01",
             "SophiaAntipolis": "net04_ext",
             "Poznan": "public_L3_v4",
-            "Gent": "Public-Net",
+            "Gent": "public-ext-net-03",
             "Crete": "net04_ext"
         }
     },


### PR DESCRIPTION
### DESCRIPTION
- Changing external network name in PiraeusU (issue #21 )
- Changing external network name in Gent (issue #22 )
- Changing external network name in Zürich (issue #20 )
- Changing in the jenkins machine setting.json and correct the name of PiraeusN (issue #18 )
### REVIEWERS

@jframos 
