### PR TITLE
Add suite_world separate dictionary to account resources on startup

### DIFF
--- a/fiware-region-sanity-tests/commons/fiware_cloud_test_case.py
+++ b/fiware-region-sanity-tests/commons/fiware_cloud_test_case.py
@@ -52,8 +52,8 @@ class FiwareTestCase(unittest.TestCase):
     # Test neutron networks (could be overriden)
     with_networks = True
 
-    # Temporal test data
-    test_world = {}
+    # Test data for the suite
+    suite_world = {}
 
     # Test logger
     logger = None
@@ -84,13 +84,14 @@ class FiwareTestCase(unittest.TestCase):
         :return: The auth token retrieved
         """
 
+        tenant_id = cls.conf[PROPERTIES_CONFIG_CRED][PROPERTIES_CONFIG_CRED_TENANT_ID]
         credentials = auth.identity.v2.Password(
             auth_url=cls.conf[PROPERTIES_CONFIG_CRED][PROPERTIES_CONFIG_CRED_KEYSTONE_URL],
             username=cls.conf[PROPERTIES_CONFIG_CRED][PROPERTIES_CONFIG_CRED_USER],
             password=cls.conf[PROPERTIES_CONFIG_CRED][PROPERTIES_CONFIG_CRED_PASS],
             tenant_name=cls.conf[PROPERTIES_CONFIG_CRED][PROPERTIES_CONFIG_CRED_TENANT_NAME])
 
-        cls.logger.debug("Getting auth token...")
+        cls.logger.debug("Getting auth token for tenant %s...", tenant_id)
         cls.auth_url = credentials.auth_url
         cls.auth_sess = session.Session(auth=credentials)
         try:
@@ -112,12 +113,12 @@ class FiwareTestCase(unittest.TestCase):
                                                          auth_session=cls.auth_sess)
 
     @classmethod
-    def init_world(cls):
+    def init_world(cls, world, suite=False):
         """
-        Init the test_world variable to store created data by tests
+        Init the `world` variable to store created data by tests
         """
 
-        cls.test_world.update({
+        world.update({
             'servers': [],
             'sec_groups': [],
             'keypair_names': [],
@@ -126,37 +127,37 @@ class FiwareTestCase(unittest.TestCase):
             'allocated_ips': []
         })
 
-        cls.reset_world_servers(init=True)
-        cls.reset_world_sec_groups(init=True)
-        cls.reset_world_keypair_names(init=True)
-        cls.reset_world_networks(init=True)
-        cls.reset_world_routers(init=True)
-        cls.reset_world_allocated_ips(init=True)
-        cls.logger.debug("test_world = %s", str(cls.test_world))
+        if suite:
+            cls.reset_world_servers(world, suite)
+            cls.reset_world_sec_groups(world, suite)
+            cls.reset_world_keypair_names(world, suite)
+            cls.reset_world_networks(world, suite)
+            cls.reset_world_routers(world, suite)
+            cls.reset_world_allocated_ips(world, suite)
 
     @classmethod
-    def reset_world_servers(cls, init=False):
+    def reset_world_servers(cls, world, suite=False):
         """
-        Init the test_world['servers'] entry (possibly, after deleting resources)
+        Init the world['servers'] entry (after deleting existing resources)
         """
 
-        if init:
+        if suite:
             # get pre-existing server list (ideally, empty when starting the tests)
             try:
                 server_list = cls.nova_operations.list_servers()
                 for server in server_list:
                     cls.logger.debug("init_world() found server '%s' not deleted", server.name)
-                    cls.test_world['servers'].append(server.id)
+                    world['servers'].append(server.id)
             except (NovaClientException, NovaConnectionRefused, KeystoneConnectionRefused) as e:
                 cls.logger.error("init_world() failed to get server list: %s", e)
 
-        # release resources to ensure a clean test_world
-        for server_id in list(cls.test_world['servers']):
+        # release resources to ensure a clean world
+        for server_id in list(world['servers']):
             try:
                 cls.nova_operations.delete_server(server_id)
                 cls.nova_operations.wait_for_task_status(server_id, 'DELETED')
             except NotFound:
-                cls.test_world['servers'].remove(server_id)
+                world['servers'].remove(server_id)
                 cls.logger.debug("Deleted instance %s", server_id)
             except (NovaClientException, NovaConnectionRefused, KeystoneConnectionRefused) as e:
                 cls.logger.error("Failed to delete server %s: %s", server_id, e)
@@ -165,129 +166,129 @@ class FiwareTestCase(unittest.TestCase):
         time.sleep(5)
 
     @classmethod
-    def reset_world_sec_groups(cls, init=False):
+    def reset_world_sec_groups(cls, world, suite=False):
         """
-        Init the test_world['sec_groups'] entry (possibly, after deleting resources)
+        Init the world['sec_groups'] entry (after deleting existing resources)
         """
 
-        if init:
+        if suite:
             # get pre-existing test security group list (ideally, empty when starting the tests)
             try:
                 sec_group_data_list = cls.nova_operations.list_security_groups(TEST_SEC_GROUP_PREFIX)
                 for sec_group_data in sec_group_data_list:
                     cls.logger.debug("init_world() found security group '%s' not deleted", sec_group_data.name)
-                    cls.test_world['sec_groups'].append(sec_group_data.id)
+                    world['sec_groups'].append(sec_group_data.id)
             except (NovaClientException, NovaConnectionRefused, KeystoneConnectionRefused) as e:
                 cls.logger.error("init_world() failed to get security group list: %s", e)
 
-        # release resources to ensure a clean test_world
-        for sec_group_id in list(cls.test_world['sec_groups']):
+        # release resources to ensure a clean world
+        for sec_group_id in list(world['sec_groups']):
             try:
                 cls.nova_operations.delete_security_group(sec_group_id)
-                cls.test_world['sec_groups'].remove(sec_group_id)
+                world['sec_groups'].remove(sec_group_id)
             except (NovaClientException, NovaConnectionRefused, KeystoneConnectionRefused) as e:
                 cls.logger.error("Failed to delete security group %s: %s", sec_group_id, e)
 
     @classmethod
-    def reset_world_keypair_names(cls, init=False):
+    def reset_world_keypair_names(cls, world, suite=False):
         """
-        Init the test_world['keypair_names'] entry (possibly, after deleting resources)
+        Init the world['keypair_names'] entry (after deleting existing resources)
         """
 
-        if init:
+        if suite:
             # get pre-existing test keypair list (ideally, empty when starting the tests)
             try:
                 keypair_list = cls.nova_operations.list_keypairs(TEST_KEYPAIR_PREFIX)
                 for keypair in keypair_list:
                     cls.logger.debug("init_world() found keypair '%s' not deleted", keypair.name)
-                    cls.test_world['keypair_names'].append(keypair.name)
+                    world['keypair_names'].append(keypair.name)
             except (NovaClientException, NovaConnectionRefused, KeystoneConnectionRefused) as e:
                 cls.logger.error("init_world() failed to get keypair list: %s", e)
 
-        # release resources to ensure a clean test_world
-        for keypair_name in list(cls.test_world['keypair_names']):
+        # release resources to ensure a clean world
+        for keypair_name in list(world['keypair_names']):
             try:
                 cls.nova_operations.delete_keypair(keypair_name)
-                cls.test_world['keypair_names'].remove(keypair_name)
+                world['keypair_names'].remove(keypair_name)
             except (NovaClientException, NovaConnectionRefused, KeystoneConnectionRefused) as e:
                 cls.logger.error("Failed to delete keypair %s: %s", keypair_name, e)
 
     @classmethod
-    def reset_world_networks(cls, init=False):
+    def reset_world_networks(cls, world, suite=False):
         """
-        Init the test_world['networks'] entry (possibly, after deleting resources)
+        Init the world['networks'] entry (after deleting existing resources)
         """
 
-        if init and cls.with_networks:
+        if suite and cls.with_networks:
             # get pre-existing test network list (ideally, empty when starting the tests)
             try:
                 network_list = cls.neutron_operations.list_networks(TEST_NETWORK_PREFIX)
                 for network in network_list:
                     cls.logger.debug("init_world() found network '%s' not deleted", network['name'])
-                    cls.test_world['networks'].append(network['id'])
+                    world['networks'].append(network['id'])
             except (NeutronClientException, KeystoneConnectionRefused) as e:
                 cls.logger.error("init_world() failed to get network list: %s", e)
 
-        # release resources to ensure a clean test_world
-        for network_id in list(cls.test_world['networks']):
+        # release resources to ensure a clean world
+        for network_id in list(world['networks']):
             try:
                 cls.neutron_operations.delete_network(network_id)
-                cls.test_world['networks'].remove(network_id)
+                world['networks'].remove(network_id)
             except (NeutronClientException, KeystoneConnectionRefused) as e:
                 cls.logger.error("Failed to delete network %s: %s", network_id, e)
 
     @classmethod
-    def reset_world_routers(cls, init=False):
+    def reset_world_routers(cls, world, suite=False):
         """
-        Init the test_world['routers'] entry (possibly, after deleting resources)
+        Init the world['routers'] entry (after deleting existing resources)
         """
 
-        if init and cls.with_networks:
+        if suite and cls.with_networks:
             # get pre-existing test router list (ideally, empty when starting the tests)
             try:
                 router_list = cls.neutron_operations.list_routers(TEST_ROUTER_PREFIX)
                 for router in router_list:
                     cls.logger.debug("init_world() found router '%s' not deleted", router['name'])
-                    cls.test_world['routers'].append(router['id'])
+                    world['routers'].append(router['id'])
             except (NeutronClientException, KeystoneConnectionRefused) as e:
                 cls.logger.error("init_world() failed to get router list: %s", e)
 
-        # release resources to ensure a clean test_world
-        for router_id in list(cls.test_world['routers']):
+        # release resources to ensure a clean world
+        for router_id in list(world['routers']):
             try:
                 cls.neutron_operations.delete_router(router_id)
-                cls.test_world['routers'].remove(router_id)
+                world['routers'].remove(router_id)
             except (NeutronClientException, KeystoneConnectionRefused) as e:
                 cls.logger.error("Failed to delete router %s: %s", router_id, e)
 
     @classmethod
-    def reset_world_allocated_ips(cls, init=False):
+    def reset_world_allocated_ips(cls, world, suite=False):
         """
-        Init the test_world['allocated_ips'] entry (possibly, after deallocating resources)
+        Init the world['allocated_ips'] entry (after deallocating existing resources)
         """
 
-        if init:
+        if suite:
             # get pre-existing allocated IP list (ideally, empty when starting the tests)
             try:
                 ip_data_list = cls.nova_operations.list_allocated_ips()
                 for ip_data in ip_data_list:
                     cls.logger.debug("init_world() found IP %s not deallocated", ip_data.ip)
-                    cls.test_world['allocated_ips'].append(ip_data.id)
+                    world['allocated_ips'].append(ip_data.id)
             except (NovaClientException, NovaConnectionRefused, KeystoneConnectionRefused) as e:
                 cls.logger.error("init_world() failed to get allocated IP list: %s", e)
 
-        # release resources to ensure a clean test_world
-        for allocated_ip_id in list(cls.test_world['allocated_ips']):
+        # release resources to ensure a clean world
+        for allocated_ip_id in list(world['allocated_ips']):
             try:
                 cls.nova_operations.deallocate_ip(allocated_ip_id)
-                cls.test_world['allocated_ips'].remove(allocated_ip_id)
+                world['allocated_ips'].remove(allocated_ip_id)
             except (NovaClientException, NovaConnectionRefused, KeystoneConnectionRefused) as e:
                 cls.logger.error("Failed to deallocate IP %s: %s", allocated_ip_id, e)
 
     @classmethod
     def setUpClass(cls):
         """
-        Setup testcase (executed before ALL tests): initialize logger and REST-Clients.
+        Setup testcase (executed before ALL tests): release resources, initialize logger and REST clients.
         """
 
         cls.logger_handler.setFormatter(logging.Formatter("%(levelname)s %(asctime)s %(message)s"))
@@ -300,15 +301,14 @@ class FiwareTestCase(unittest.TestCase):
 
         # Load properties from config file
         cls.load_project_properties()
-        username = cls.conf[PROPERTIES_CONFIG_CRED][PROPERTIES_CONFIG_CRED_USER]
         tenant_id = cls.conf[PROPERTIES_CONFIG_CRED][PROPERTIES_CONFIG_CRED_TENANT_ID]
         test_flavor = cls.conf[PROPERTIES_CONFIG_REGION][PROPERTIES_CONFIG_REGION_TEST_FLAVOR].get(cls.region_name)
-        cls.logger.debug("Settings = {'user': '%s', 'tenant': '%s'}", username, tenant_id)
 
         # Initialize session trying to get auth token; on success, continue with initialization
         if cls.init_auth():
             cls.init_clients(tenant_id, test_flavor)
-            cls.init_world()
+            cls.init_world(cls.suite_world, suite=True)
+            cls.logger.debug("suite_world = %s", cls.suite_world)
 
     @classmethod
     def tearDownClass(cls):

--- a/fiware-region-sanity-tests/tests/fiware_region_base_tests.py
+++ b/fiware-region-sanity-tests/tests/fiware_region_base_tests.py
@@ -39,6 +39,11 @@ class FiwareRegionsBaseTests(FiwareTestCase):
         super(FiwareRegionsBaseTests, cls).setUpClass()
         cls.region_conf = cls.conf[PROPERTIES_CONFIG_REGION]
 
+    def setUp(self):
+        super(FiwareRegionsBaseTests, self).setUp()
+        self.test_world = {}
+        self.init_world(self.test_world)
+
     def test_flavors_not_empty(self):
         """
         Test whether region has flavors
@@ -128,24 +133,24 @@ class FiwareRegionsBaseTests(FiwareTestCase):
 
         if self.test_world.get('servers'):
             self.logger.debug("Tearing down servers...")
-            self.reset_world_servers()
+            self.reset_world_servers(self.test_world)
 
         if self.test_world.get('sec_groups'):
             self.logger.debug("Tearing down security groups...")
-            self.reset_world_sec_groups()
+            self.reset_world_sec_groups(self.test_world)
 
         if self.test_world.get('keypair_names'):
             self.logger.debug("Tearing down keypairs...")
-            self.reset_world_keypair_names()
+            self.reset_world_keypair_names(self.test_world)
 
         if self.test_world.get('networks'):
             self.logger.debug("Tearing down networks...")
-            self.reset_world_networks()
+            self.reset_world_networks(self.test_world)
 
         if self.test_world.get('routers'):
             self.logger.debug("Tearing down routers...")
-            self.reset_world_routers()
+            self.reset_world_routers(self.test_world)
 
         if self.test_world.get('allocated_ips'):
             self.logger.debug("Tearing down allocated IPs...")
-            self.reset_world_allocated_ips()
+            self.reset_world_allocated_ips(self.test_world)

--- a/fiware-region-sanity-tests/tests/fiware_region_with_networks_tests.py
+++ b/fiware-region-sanity-tests/tests/fiware_region_with_networks_tests.py
@@ -144,6 +144,11 @@ class FiwareRegionWithNetworkTest(fiware_region_base_tests.FiwareRegionsBaseTest
         """
         Test whether it is possible to create a new router with a default gateway
         """
+
+        # skip test if suite couldn't start from an empty, clean list of allocated IPs (to avoid cascading failures)
+        if self.suite_world['allocated_ips']:
+            self.skipTest("There were pre-existing, not deallocated IPs")
+
         # First, get external network id
         external_network_id = None
         external_network_list = self.neutron_operations.find_networks(router_external=True)


### PR DESCRIPTION
#### Reviewers

@flopezag, @jframos 
#### Description

Initial resources are accounted in a "suite_world" dictionary (thus, initial cleanup considers this), while "test_world" is reserved to any single test execution, always initialized to an empty, clean world.
#### Testing

Verified in several regions.
