### PR TITLE
FIX port type from router to network interface when deleting ports

### DIFF
--- a/fiware-region-sanity-tests/commons/fiware_cloud_test_case.py
+++ b/fiware-region-sanity-tests/commons/fiware_cloud_test_case.py
@@ -320,7 +320,7 @@ class FiwareTestCase(unittest.TestCase):
         for port_id in list(world['ports']):
             try:
                 port_data = cls.neutron_operations.show_port(port_id)
-                if 'network:router_interface' == port_data['device_owner']:
+                if 'network:router_interface' in port_data['device_owner']:
                     for fixed_ip in port_data['fixed_ips']:
                         cls.neutron_operations.delete_interface_router(router_id=port_data['device_id'],
                                                                        subnetwork_id=fixed_ip['subnet_id'])


### PR DESCRIPTION
#### Reviewers

@flopezag @pratid 
#### Description

In some regions (for instance: Spain2) the port type from router to network is "router_interface_distributed" and not "router_interface"
#### Tested

The teardown script has been tested locally in Spain2
