### PR TITLE
Add server filtering by prefix

### DIFF
--- a/fiware-region-sanity-tests/commons/fiware_cloud_test_case.py
+++ b/fiware-region-sanity-tests/commons/fiware_cloud_test_case.py
@@ -159,7 +159,7 @@ class FiwareTestCase(unittest.TestCase):
         if suite:
             # get pre-existing server list (ideally, empty when starting the tests)
             try:
-                server_list = cls.nova_operations.list_servers()
+                server_list = cls.nova_operations.list_servers(TEST_SERVER_PREFIX)
                 for server in server_list:
                     cls.logger.debug("init_world() found server '%s' not deleted", server.name)
                     world['servers'].append(server.id)

--- a/fiware-region-sanity-tests/commons/nova_operations.py
+++ b/fiware-region-sanity-tests/commons/nova_operations.py
@@ -237,12 +237,17 @@ class FiwareNovaOperations:
         """
         self.client.servers.delete(instance_id)
 
-    def list_servers(self):
+    def list_servers(self, name_prefix=None):
         """
         Gets all the servers of the tenant
+        :param name_prefix: Prefix to match server names
         :return: A list of :class:`Server`
         """
-        return self.client.servers.list()
+        server_list = self.client.servers.list()
+        if name_prefix:
+            server_list = [server for server in server_list if server.name.startswith(name_prefix)]
+
+        return server_list
 
     def wait_for_task_status(self, server_id, expected_status):
         """


### PR DESCRIPTION
#### Reviewers

@flopezag @jframos 
#### Description

Solves bug 4903: restricts servers to be torn down to those whose name starts with a prefix
#### Testing

Successfully tests on several nodes
