### PR TITLE
Add verbose deploy status errors in log messages

### DIFF
--- a/fiware-region-sanity-tests/commons/nova_operations.py
+++ b/fiware-region-sanity-tests/commons/nova_operations.py
@@ -258,8 +258,12 @@ class FiwareNovaOperations:
         detail = "Server NOT {} after {} seconds".format(expected_status, MAX_WAIT_ITERATIONS * SLEEP_TIME)
         for i in range(MAX_WAIT_ITERATIONS):
             server_data = self.get_server(server_id)
-            if server_data['status'] == expected_status or server_data['status'] == 'ERROR':
-                detail = "Server " + ("NOT " if server_data['status'] == 'ERROR' else "") + expected_status
+            if server_data['status'] == expected_status:
+                detail = "Server %s" % expected_status
+                break
+            elif server_data['status'] == 'ERROR':
+                detail = server_data.get('fault', {'message': "Server NOT %s" % expected_status})['message']
+                self.logger.error(detail)
                 break
 
             self.logger.debug("Waiting (#%d) for status %s of instance %s (current is %s)...",


### PR DESCRIPTION
#### Reviewers

@flopezag 
#### Description

Solves issue 5001 (more verbosity when Nova reports ERROR as instance status when deploying)
#### Testing

Verified in Spain2.
