### PR TITLE
Changing network name in Trento

### DIFF
--- a/fiware-region-sanity-tests/resources/settings.json
+++ b/fiware-region-sanity-tests/resources/settings.json
@@ -14,7 +14,7 @@
     "region_configuration": {
         "external_network_name": {
             "Spain2": "public-ext-net-01",
-            "Trento": "public-ext-net-01",
+            "Trento": "public-ext-net-02",
             "Lannion2": "public-ext-net-01",
             "Waterford": "public-ext-net-01",
             "Berlin2": "public-ext-net-01",


### PR DESCRIPTION
## REVIEWERS

@jframos 
## DESCRIPTION
- Correct in master the network name in order that we can pass the test previously to the modification of the next RC.
- Resolve issue #91 
