### PR TITLE
Add forever to monitor execution of server

### DIFF
--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -29,6 +29,7 @@
     "domain": "0.0.1",
     "express": "~4.12.2",
     "express-session": "^1.11.1",
+    "forever": "^0.14.1",
     "jade": "~1.9.2",
     "logops": "^0.2.0",
     "nib": "^1.1.0",

--- a/dashboard/tools/build/files/redhat/SOURCES/etc/init.d/fihealth_dashboard
+++ b/dashboard/tools/build/files/redhat/SOURCES/etc/init.d/fihealth_dashboard
@@ -22,26 +22,30 @@
 PATH=/sbin:/usr/sbin:/bin:/usr/bin
 DESC="FiHealth Dashboard"
 NAME=fihealth_dashboard
-DAEMON=/opt/fiware/$NAME/bin/dashboard
+DAEMON_DIR=/opt/fiware/$NAME
+DAEMON_BIN=bin/dashboard
 DAEMON_ARGS=""
 DAEMON_USER=fiware
+FOREVER_DIR=/var/run/fiware/.forever
 LOGFILE=/var/log/$NAME/$NAME.log
-PIDFILE=/var/run/$NAME.pid
+PIDFILE=$FOREVER_DIR/pids/$NAME.pid
 SCRIPTNAME=/etc/init.d/$NAME
 
-# Exit if the component is not installed
-[ -x "$DAEMON" ] || exit 0
-
 # Read configuration variable files, if present
-[ -r /etc/profile ]	      && . /etc/profile
-[ -r /etc/sysconfig/$NAME ]   && . /etc/sysconfig/$NAME
+[ -r /etc/profile ]		&& . /etc/profile
+[ -r /etc/sysconfig/$NAME ]	&& . /etc/sysconfig/$NAME
 
 # Check that networking is up
-[ -r /etc/sysconfig/network ] && . /etc/sysconfig/network
-[ "${NETWORKING}" = "no" ] && exit 0
+[ -r /etc/sysconfig/network ]	&& . /etc/sysconfig/network
+[ "${NETWORKING}" = "no" ]	&& exit 0
 
 # Source function library
 . /etc/rc.d/init.d/functions
+
+# Workaround to set forever path for auxiliary files
+FOREVER="HOME=$(dirname $FOREVER_DIR) $DAEMON_DIR/node_modules/.bin/forever"
+FOREVER_OPTS="-p $FOREVER_DIR -l $LOGFILE -o $LOGFILE -e $LOGFILE \
+	--append --silent --no-colors"
 
 # Function that checks configuration
 do_checkup()
@@ -62,24 +66,22 @@ do_checkup()
 # Function that starts the daemon/service
 do_start()
 {
-	local pid
-	local startup="$DAEMON $DAEMON_ARGS"
-	do_checkup && action $"Starting $NAME:" daemon \
-		--user=$DAEMON_USER --pidfile=$PIDFILE \
-		"$startup >> $LOGFILE &"
+	local options="$FOREVER_OPTS --minUptime 1000 --spinSleepTime 1000"
+	local startup="$FOREVER start $options --uid $NAME $DAEMON_BIN"
+	cd $DAEMON_DIR \
+	&& do_checkup \
+	&& action $"Starting $NAME:" daemon --user=$DAEMON_USER "$startup"
 	RETVAL=$?
-	if [ "$RETVAL" = 0 ]; then
-		pid=$(ps -u$DAEMON_USER -opid,args:250,ppid \
-		      | awk '$(NF-1)=="'$DAEMON'" && $NF==1 {print $1}')
-		echo $pid > $PIDFILE
-	fi
 	echo
 }
 
 # Function that stops the daemon/service
 do_stop()
 {
-	do_checkup && action $"Stopping $NAME:" killproc -p $PIDFILE "$NAME"
+	local stop="$FOREVER stop $FOREVER_OPTS $NAME"
+	cd $DAEMON_DIR \
+	&& do_checkup \
+	&& action $"Stopping $NAME:" daemon --user=$DAEMON_USER "$stop"
 	RETVAL=$?
 	echo
 }

--- a/dashboard/tools/build/files/redhat/SPECS/fiware-fihealth-dashboard.spec
+++ b/dashboard/tools/build/files/redhat/SPECS/fiware-fihealth-dashboard.spec
@@ -8,6 +8,7 @@
 %define _dashboard_grp %{_fiware_grp}
 %define _dashboard_dir %{_fiware_dir}/%{_dashboard_srv}
 %define _logging_dir /var/log/%{_dashboard_srv}
+%define _forever_dir /var/run/fiware/.forever
 %define _node_req_ver %(awk '/"node":/ {split($0,v,/["~=<>]/); print v[6]}' %{_basedir}/package.json)
 
 # Package main attributes (_topdir, _basedir, _version and _release must be given at command line)
@@ -109,10 +110,12 @@ if [ $1 -eq 1 ]; then
 	DASHBOARD_GRP=%{_dashboard_grp}
 	DASHBOARD_DIR=%{_dashboard_dir}
 	LOGGING_DIR=%{_logging_dir}
+	FOREVER_DIR=%{_forever_dir}
 	STATUS=0
 
 	# create additional directories
 	mkdir -p $LOGGING_DIR
+	mkdir -p $FOREVER_DIR
 
 	# install npm dependencies
 	echo "Installing npm dependencies ..."
@@ -141,6 +144,7 @@ if [ $1 -eq 1 ]; then
 
 	# change ownership
 	chown -R $FIWARE_USR:$FIWARE_GRP $FIWARE_DIR
+	chown -R $FIWARE_USR:$FIWARE_GRP $FOREVER_DIR
 	chown -R $DASHBOARD_USR:$DASHBOARD_GRP $DASHBOARD_DIR
 	chown -R $DASHBOARD_USR:$DASHBOARD_GRP $LOGGING_DIR
 
@@ -189,11 +193,17 @@ if [ $1 -eq 0 ]; then
 	# remove FIWARE parent directory, if empty
 	[ -d %{_fiware_dir} ] && rmdir --ignore-fail-on-non-empty %{_fiware_dir}
 
+	# remove FIWARE Forever directory, if empty
+	[ -d %{_forever_dir} ] && rmdir --ignore-fail-on-non-empty %{_forever_dir}
+
 	# remove log files
 	rm -rf %{_logging_dir}
 fi
 
 %changelog
+* Thu Jun 03 2015 Telefónica I+D <opensource@tid.es> 1.0.0-2
+- Add forever to monitor the execution of the server.
+
 * Fri May 29 2015 Telefónica I+D <opensource@tid.es> 1.0.0-1
 - New overview and details pages.
 - IdM authentication.

--- a/dashboard/tools/build/package.sh
+++ b/dashboard/tools/build/package.sh
@@ -95,7 +95,7 @@ create_rpm_package() {
 	         --define "_topdir $topdir" \
 	         --define "_basedir $BASEDIR" \
 	         --define "_version ${VERSION:-$pkgversion}" \
-	         --define "_release 1" \
+	         --define "_release 2" \
 	&& rpmbuild_file=$(find RPMS/ -name *.rpm) \
 	&& package=$(basename $rpmbuild_file) \
 	&& mv -f $rpmbuild_file $BASEDIR \


### PR DESCRIPTION
#### Reviewers

@flopezag @jframos 
#### Description

Change the way Linux service starts the Dashboard server: use forever to keep it up & running.
#### Testing

Verified.
#### Release notes

Release 2 of version 1.0.0 (fiware-fihealth-dashboard-1.0.0-**2**.noarch.rpm)
