### PR TITLE
Use new sanity timestamp attribute

### DIFF
--- a/dashboard/lib/routes/cbroker.js
+++ b/dashboard/lib/routes/cbroker.js
@@ -24,7 +24,7 @@ var http = require('http'),
 
 
 var SANITY_STATUS_ATTRIBUTE = 'sanity_status', // field name for value about regions status
-    TIMESTAMP_ATTRIBUTE = '_timestamp', // field name for value about timestamp
+    TIMESTAMP_ATTRIBUTE = 'sanity_check_timestamp', // field name for value about timestamp
     REGION_TYPE = 'region';
 
 

--- a/dashboard/test/unit/post1.json
+++ b/dashboard/test/unit/post1.json
@@ -4,7 +4,7 @@
             "contextElement": {
                 "attributes": [
                     {
-                        "name": "_timestamp",
+                        "name": "sanity_check_timestamp",
                         "type": "string",
                         "value": "1431515409572"
                     },
@@ -27,7 +27,7 @@
             "contextElement": {
                 "attributes": [
                     {
-                        "name": "_timestamp",
+                        "name": "sanity_check_timestamp",
                         "type": "string",
                         "value": "1431515409572"
                     },
@@ -50,7 +50,7 @@
             "contextElement": {
                 "attributes": [
                     {
-                        "name": "_timestamp",
+                        "name": "sanity_check_timestamp",
                         "type": "string",
                         "value": "1431515409572"
                     },
@@ -73,7 +73,7 @@
             "contextElement": {
                 "attributes": [
                     {
-                        "name": "_timestamp",
+                        "name": "sanity_check_timestamp",
                         "type": "string",
                         "value": "1431515409572"
                     },

--- a/fiware-region-sanity-tests/resources/parsers/sanity_tests.js
+++ b/fiware-region-sanity-tests/resources/parsers/sanity_tests.js
@@ -51,11 +51,11 @@ var parser = Object.create(require('./common/base').parser);
  * @function parseRequest
  * @memberof parser
  * @param {http.IncomingMessage} request    The HTTP request to this server.
- * @returns {EntityData} An object with `status` and `summary` members.
+ * @returns {EntityData} An object with `status`, `summary` and `timestamp` members.
  */
 parser.parseRequest = function(request) {
     var items = request.body.split(/^\*+$/m);
-    return { status: items[0], summary: items[1] };
+    return { status: items[0], summary: items[1], timestamp: request.timestamp };
 };
 
 
@@ -171,6 +171,9 @@ parser.getContextAttrs = function(probeEntityData) {
     } else if (opt_status_line.match(/>>\s+\b\w+\b/)) {
         attrs['sanity_status'] = GLOBAL_STATUS_PARTIAL_OK;
     }
+
+    // Timestamp for tests results
+    attrs['sanity_check_timestamp'] = probeEntityData.timestamp;
 
     // Individual tests results
     summary.map(function(item) {


### PR DESCRIPTION
#### Reviewers

@jframos 
#### Description

As part of US 5083, a new attribute `sanity_check_timestamp` is introduced not to depend on standard `_timestamp` which may vary when other monitoring attributes are updated.
#### Testing

Verified.
