### PR TITLE
Hotfix/claudia 5318

### DIFF
--- a/fiware-region-sanity-tests/commons/constants.py
+++ b/fiware-region-sanity-tests/commons/constants.py
@@ -72,6 +72,7 @@ TEST_ROUTER_PREFIX = "testing_router"
 TEST_CONTAINER_PREFIX = "testing_container"
 TEST_TEXT_OBJECT_PREFIX = "testing_text_object"
 TEST_BIG_OBJECT_PREFIX = "test_big_file"
+TEST_BIG_OBJECT_REMOTE_PREFIX = "remote_"
 TEST_TEXT_FILE_EXTENSION = ".txt"
 TEST_BIG_FILE_EXTENSION = ".zip"
 

--- a/fiware-region-sanity-tests/commons/fiware_cloud_test_case.py
+++ b/fiware-region-sanity-tests/commons/fiware_cloud_test_case.py
@@ -411,7 +411,8 @@ class FiwareTestCase(unittest.TestCase):
                     try:
                         world['swift_objects'].remove(container + "/" + object["name"])
                     except ValueError:
-                        cls.logger.warn("This object was removed and it came from an older execution: %s", container + "/" + object["name"])
+                        cls.logger.warn("This object was removed and it came from an older execution: %s",
+                                        container + "/" + object["name"])
                 cls.swift_operations.delete_container(container)
                 world['containers'].remove(container)
             except (SwiftClientException, KeystoneConnectionRefused, KeystoneRequestTimeout, ConnectionError) as e:

--- a/fiware-region-sanity-tests/commons/fiware_cloud_test_case.py
+++ b/fiware-region-sanity-tests/commons/fiware_cloud_test_case.py
@@ -408,7 +408,10 @@ class FiwareTestCase(unittest.TestCase):
             try:
                 for object in cls.swift_operations.get_container(container)[-1]:
                     cls.swift_operations.delete_object(container, object["name"])
-                    world['swift_objects'].remove(container + "/" + object["name"])
+                    try:
+                        world['swift_objects'].remove(container + "/" + object["name"])
+                    except ValueError:
+                        cls.logger.warn("This object was removed and it came from an older execution: %s", container + "/" + object["name"])
                 cls.swift_operations.delete_container(container)
                 world['containers'].remove(container)
             except (SwiftClientException, KeystoneConnectionRefused, KeystoneRequestTimeout, ConnectionError) as e:
@@ -430,7 +433,10 @@ class FiwareTestCase(unittest.TestCase):
         # release resources to ensure a clean world
         for local_file in list(world['local_objects']):
                 os.remove(SWIFT_RESOURCES_PATH + local_file)
-                world['local_objects'].remove(local_file)
+                try:
+                    world['local_objects'].remove(local_file)
+                except ValueError:
+                    cls.logger.warn("This file was removed and it came from an older execution: %s", local_file)
 
     @classmethod
     def setUpClass(cls):

--- a/fiware-region-sanity-tests/tests/fiware_region_object_storage_tests.py
+++ b/fiware-region-sanity-tests/tests/fiware_region_object_storage_tests.py
@@ -161,8 +161,9 @@ class FiwareRegionsObjectStorageTests(FiwareRegionsBaseTests):
 
         suffix = datetime.utcnow().strftime('%Y%m%d%H%M%S%m')
         containerName = TEST_CONTAINER_PREFIX + suffix
-        big_object_name = TEST_BIG_OBJECT_PREFIX + suffix + TEST_BIG_FILE_EXTENSION
-        remote_big_object_name = TEST_BIG_OBJECT_REMOTE_PREFIX + TEST_BIG_OBJECT_PREFIX + suffix + TEST_BIG_FILE_EXTENSION
+        big_object_name = self.region_name + TEST_BIG_OBJECT_PREFIX + suffix + TEST_BIG_FILE_EXTENSION
+        remote_big_object_name = TEST_BIG_OBJECT_REMOTE_PREFIX + TEST_BIG_OBJECT_PREFIX + suffix \
+                                 + TEST_BIG_FILE_EXTENSION
 
         response = self.swift_operations.create_container(containerName)
         self.assertIsNone(response, "Container could not be created")
@@ -173,8 +174,11 @@ class FiwareRegionsObjectStorageTests(FiwareRegionsBaseTests):
         big_file_url_1 = self.conf[PROPERTIES_CONFIG_TEST][PROPERTIES_CONFIG_SWIFT][PROPERTIES_CONFIG_SWIFT_BIG_FILE_1]
         f = urllib2.urlopen(big_file_url_1)
         data = f.read()
-        with open(SWIFT_RESOURCES_PATH + big_object_name, "wb") as code:
-            code.write(data)
+        try:
+            with open(SWIFT_RESOURCES_PATH + big_object_name, "wb") as code:
+                code.write(data)
+        except IOError:
+            self.logger.error("Error while writing %s file", SWIFT_RESOURCES_PATH + big_object_name)
 
         self.test_world['local_objects'].append(big_object_name)
 
@@ -182,7 +186,7 @@ class FiwareRegionsObjectStorageTests(FiwareRegionsBaseTests):
         response = self.swift_operations.create_object(containerName, SWIFT_RESOURCES_PATH
                                                             + big_object_name,
                                                             remote_big_object_name)
-        origin = hashlib.md5(open(SWIFT_RESOURCES_PATH + big_object_name, 'rb')
+        originHash = hashlib.md5(open(SWIFT_RESOURCES_PATH + big_object_name, 'rb')
                           .read()).hexdigest()
 
         self.assertIsNotNone(response, "Object could not be created")
@@ -195,18 +199,23 @@ class FiwareRegionsObjectStorageTests(FiwareRegionsBaseTests):
         self.assertTrue(response, "Object could not be downloaded")
         self.test_world['local_objects'].append(remote_big_object_name)
 
-        remote = hashlib.md5(open(SWIFT_RESOURCES_PATH + remote_big_object_name, 'rb').read()).hexdigest()
+        remoteHash = hashlib.md5(open(SWIFT_RESOURCES_PATH + remote_big_object_name, 'rb').read()).hexdigest()
 
         # Checking original file with remote file
-        self.assertEqual(origin, remote, "The original file and the downloaded file are different")
+        self.assertEqual(originHash, remoteHash, "The original file and the downloaded file are different")
 
         # Downloading a second big file to check that is different
         suffix2 = datetime.utcnow().strftime('%Y%m%d%H%M%S%m')
         big_file_url_2 = self.conf[PROPERTIES_CONFIG_TEST][PROPERTIES_CONFIG_SWIFT][PROPERTIES_CONFIG_SWIFT_BIG_FILE_2]
         f2 = urllib2.urlopen(big_file_url_2)
         data = f2.read()
-        with open(SWIFT_RESOURCES_PATH + TEST_BIG_OBJECT_PREFIX + suffix2 + TEST_BIG_FILE_EXTENSION, "wb") as code2:
-            code2.write(data)
+        try:
+            with open(SWIFT_RESOURCES_PATH + TEST_BIG_OBJECT_PREFIX + suffix2 + TEST_BIG_FILE_EXTENSION, "wb") as code2:
+                code2.write(data)
+        except IOError:
+            self.logger.error("Error while writing %s file", SWIFT_RESOURCES_PATH + TEST_BIG_OBJECT_PREFIX +
+                              suffix2 + TEST_BIG_FILE_EXTENSION)
+
         self.test_world['local_objects'].append(TEST_BIG_OBJECT_PREFIX + suffix2 + TEST_BIG_FILE_EXTENSION)
 
         # Checking that two different files generates are different
@@ -214,5 +223,5 @@ class FiwareRegionsObjectStorageTests(FiwareRegionsBaseTests):
                                    'rb')
                               .read()).hexdigest()
 
-        self.assertNotEqual(origin2, remote, "The second file and the downloaded file are the same, "
+        self.assertNotEqual(origin2, remoteHash, "The second file and the downloaded file are the same, "
                                              "it cannot be possible")

--- a/fiware-region-sanity-tests/tests/regions/test_spain2.py
+++ b/fiware-region-sanity-tests/tests/regions/test_spain2.py
@@ -24,8 +24,9 @@
 __author__ = 'fla'
 
 
-from tests import fiware_region_with_networks_tests
+from tests import fiware_region_with_networks_tests, fiware_region_object_storage_tests
 
 
-class TestSuite(fiware_region_with_networks_tests.FiwareRegionWithNetworkTest):
+class TestSuite(fiware_region_with_networks_tests.FiwareRegionWithNetworkTest,
+                fiware_region_object_storage_tests.FiwareRegionsObjectStorageTests):
     region_name = "Spain2"


### PR DESCRIPTION
### REVIEWERS

@flopezag @jframos
### DESCRIPTION

Fixing found errors when there are two or more different executions of tests at the same time.
Fixing errors when object storage test files of previous executions are not deleted.
