### PR TITLE
Change SophiaAntipolis ext-net name and remove ObjectStorage test cases for Mexico

### DIFF
--- a/fiware-region-sanity-tests/resources/settings.json
+++ b/fiware-region-sanity-tests/resources/settings.json
@@ -32,7 +32,7 @@
             "Volos": "public-ext-net-01",
             "Budapest2": "public-ext-net-01",
             "Stockholm2": "public-ext-net-01",
-            "SophiaAntipolis": "net04_ext",
+            "SophiaAntipolis": "public-ext-net-01",
             "Poznan": "public-ext-net-01",
             "Gent": "public-ext-net-03",
             "Crete": "public-ext-net-01",

--- a/fiware-region-sanity-tests/tests/regions/test_mexico.py
+++ b/fiware-region-sanity-tests/tests/regions/test_mexico.py
@@ -24,9 +24,8 @@
 __author__ = 'jfernandez'
 
 
-from tests import fiware_region_with_networks_tests, fiware_region_object_storage_tests
+from tests import fiware_region_with_networks_tests
 
 
-class TestSuite(fiware_region_with_networks_tests.FiwareRegionWithNetworkTest,
-                fiware_region_object_storage_tests.FiwareRegionsObjectStorageTests):
+class TestSuite(fiware_region_with_networks_tests.FiwareRegionWithNetworkTest):
     region_name = "Mexico"


### PR DESCRIPTION
#### Reviewers

@geonexus @flopezag 
#### Description

Change SophiaAntipolis _external_network_name_. Solve the issue #148.
Remove ObjectStorage test cases for Trento.
