### PR TITLE
Generated name to be used as 'hostname' in the VM should include the region name

### DIFF
--- a/fiware-region-sanity-tests/tests/fiware_region_with_networks_tests.py
+++ b/fiware-region-sanity-tests/tests/fiware_region_with_networks_tests.py
@@ -431,7 +431,7 @@ class FiwareRegionWithNetworkTest(FiwareRegionsBaseTests):
         self.test_world['ports'].append(port_id)
 
         # Deploy VM
-        instance_name = TEST_SERVER_PREFIX + "_snat_" + suffix
+        instance_name = self.region_name + "_" + TEST_SERVER_PREFIX + "_snat_" + suffix
         server_id = self.__deploy_instance_helper__(instance_name=instance_name,
                                                     network_name=network_name, is_network_new=False,
                                                     userdata=userdata_content)
@@ -501,7 +501,7 @@ class FiwareRegionWithNetworkTest(FiwareRegionsBaseTests):
         metadata = {"region": self.region_name, "foo": "bar-" + suffix}
 
         # Deploy VM
-        instance_name = TEST_SERVER_PREFIX + "_meta_" + suffix
+        instance_name = self.region_name + "_" + TEST_SERVER_PREFIX + "_meta_" + suffix
         server_id = self.__deploy_instance_helper__(instance_name=instance_name,
                                                     network_name=network_name, is_network_new=False,
                                                     metadata=metadata,

--- a/fiware-region-sanity-tests/tests/fiware_region_without_networks_tests.py
+++ b/fiware-region-sanity-tests/tests/fiware_region_without_networks_tests.py
@@ -212,7 +212,7 @@ class FiwareRegionWithoutNetworkTest(FiwareRegionsBaseTests):
 
         # Deploy VM
         suffix = datetime.utcnow().strftime('%Y%m%d%H%M%S')
-        instance_name = TEST_SERVER_PREFIX + "_snat_" + suffix
+        instance_name = self.region_name + "_" + TEST_SERVER_PREFIX + "_snat_" + suffix
         server_id = self.__deploy_instance_helper__(instance_name=instance_name,
                                                     userdata=userdata_content)
 
@@ -264,7 +264,7 @@ class FiwareRegionWithoutNetworkTest(FiwareRegionsBaseTests):
         metadata = {"region": self.region_name, "foo": "bar-" + suffix}
 
         # Deploy VM
-        instance_name = TEST_SERVER_PREFIX + "_meta_" + suffix
+        instance_name = self.region_name + "_" + TEST_SERVER_PREFIX + "_meta_" + suffix
         server_id = self.__deploy_instance_helper__(instance_name=instance_name,
                                                     metadata=metadata,
                                                     userdata=userdata_content)


### PR DESCRIPTION
### REVIEWERS

@flopezag @jframos 
### DESCRIPTION

Generated name to be used as 'hostname' in the VM now includes the region name in phonehome tests
