### PR TITLE
[BUG] ADD oslo dependencies to 'requirements.txt' file

### DIFF
--- a/fiware-region-sanity-tests/requirements.txt
+++ b/fiware-region-sanity-tests/requirements.txt
@@ -1,4 +1,7 @@
 oslo.i18n==1.7.0
+oslo.config==1.13.0
+oslo.serialization==1.6.0
+oslo.utils==1.7.0
 python-novaclient==2.23.0
 python-neutronclient==2.3.11
 python-keystoneclient==1.3.0


### PR DESCRIPTION
#### Reviewers

@geonexus 
#### Description

Fixes the issue **CLAUDIA-5316** / **OPS-404**: _FIWARE.Bug.Ops.Health.Dashboard.PiraeusNProblem_
New version of _oslo.*_ python libs have been released. Our _python-keystoneclient==1.3.0_ dependency seems to use the latest version of that lib, but this lib is not compatible with the former.
