### PR TITLE
Fix version of nan dependency

### DIFF
--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -35,6 +35,7 @@
     "nib": "^1.1.0",
     "optimist": "^0.6.1",
     "serve-favicon": "~2.2.0",
+    "nan": "^1.8.4",
     "sleep": "^2.0.0",
     "stylus": "^0.51.1",
     "underscore": "^1.8.3",


### PR DESCRIPTION
#### Reviewers

@jframos 
#### Description

Explicitly add version of nan dependency, required by sleep 2.0.0 (newer versions of nan are not backward compatible and require upgrading sleep).
#### Testing

Verified.
