### PR TITLE
Hotfix/claudia 5346 update regions tests

### DIFF
--- a/fiware-region-sanity-tests/tests/regions/test_waterford.py
+++ b/fiware-region-sanity-tests/tests/regions/test_waterford.py
@@ -24,9 +24,8 @@
 __author__ = 'jfernandez'
 
 
-from tests import fiware_region_with_networks_tests, fiware_region_object_storage_tests
+from tests import fiware_region_with_networks_tests
 
 
-class TestSuite(fiware_region_with_networks_tests.FiwareRegionWithNetworkTest,
-                fiware_region_object_storage_tests.FiwareRegionsObjectStorageTests):
+class TestSuite(fiware_region_with_networks_tests.FiwareRegionWithNetworkTest):
     region_name = "Waterford"


### PR DESCRIPTION
#### Reviewers

@jframos 
#### Description

Fix task 5346, Disable the Object Storage tests in Waterford due to problems with identity in object storage with keystone and they decide disable the object storage service for now.
