### PR TITLE
Fix parsing when a nose.* error is captured and include in xUnit report

### DIFF
--- a/fiware-region-sanity-tests/commons/results_analyzer.py
+++ b/fiware-region-sanity-tests/commons/results_analyzer.py
@@ -39,6 +39,7 @@ ATTR_TESTS_FAILURE = "failures"
 CHILD_NODE_SKIP = "skipped"
 CHILD_NODE_ERROR = "error"
 CHILD_NODE_FAILURE = "failure"
+CHILD_NODE_OTHER = None
 
 TEST_STATUS_NOT_OK = "NOK"
 TEST_STATUS_SKIP = "N/A"
@@ -73,7 +74,7 @@ class ResultAnalyzer(object):
             status = TEST_STATUS_OK
             child_node_list = testcase.childNodes
             if child_node_list is not None and len(child_node_list) != 0:
-                if child_node_list[0].localName in [CHILD_NODE_FAILURE, CHILD_NODE_ERROR, None]:
+                if child_node_list[0].localName in [CHILD_NODE_FAILURE, CHILD_NODE_ERROR, CHILD_NODE_OTHER]:
                     status = TEST_STATUS_NOT_OK
                 elif child_node_list[0].localName == CHILD_NODE_SKIP:
                     status = TEST_STATUS_SKIP

--- a/fiware-region-sanity-tests/commons/results_analyzer.py
+++ b/fiware-region-sanity-tests/commons/results_analyzer.py
@@ -73,18 +73,20 @@ class ResultAnalyzer(object):
             status = TEST_STATUS_OK
             child_node_list = testcase.childNodes
             if child_node_list is not None and len(child_node_list) != 0:
-                if child_node_list[0].localName in [CHILD_NODE_FAILURE, CHILD_NODE_ERROR]:
+                if child_node_list[0].localName in [CHILD_NODE_FAILURE, CHILD_NODE_ERROR, None]:
                     status = TEST_STATUS_NOT_OK
                 elif child_node_list[0].localName == CHILD_NODE_SKIP:
                     status = TEST_STATUS_SKIP
 
-            testpackage = testcase.getAttribute('classname').split(".")[-2]
-            testregion = testpackage.replace("test_", "")
-            info_test = {"test_name": testcase.getAttribute('name'), "status": status}
-            if testregion in self.dict:
-                self.dict[testregion].append(info_test)
-            else:
-                self.dict.update({testregion: [info_test]})
+            testclass = testcase.getAttribute('classname')
+            if re.match(testclass, "\.test_.+\.TestSuite$"):
+                testpackage = testclass.split(".")[-2]
+                testregion = testpackage.replace("test_", "")
+                info_test = {"test_name": testcase.getAttribute('name'), "status": status}
+                if testregion in self.dict:
+                    self.dict[testregion].append(info_test)
+                else:
+                    self.dict.update({testregion: [info_test]})
 
     def print_results(self):
         """


### PR DESCRIPTION
#### Reviewers

@jframos 
#### Description

As detailed in bug 5196, there was a problem related to 'results_analyzer.py'. When an exception is raised by `nose` itself during the tests, classname in corresponding xUnit report doesn't match the expected pattern "test.????.test_<region>.TestSuite" and this was leading to a wrong output from the analyzer.
#### Testing

Verified with sample xUnit report attached to the bug.
