### PR TITLE
Fix parsing when a nose.* error is captured and include in xUnit report (II)

### DIFF
--- a/fiware-region-sanity-tests/commons/results_analyzer.py
+++ b/fiware-region-sanity-tests/commons/results_analyzer.py
@@ -80,7 +80,7 @@ class ResultAnalyzer(object):
                     status = TEST_STATUS_SKIP
 
             testclass = testcase.getAttribute('classname')
-            if re.match(testclass, "\.test_.+\.TestSuite$"):
+            if re.match(".*\.test_.+\.TestSuite$", testclass):
                 testpackage = testclass.split(".")[-2]
                 testregion = testpackage.replace("test_", "")
                 info_test = {"test_name": testcase.getAttribute('name'), "status": status}

--- a/fiware-region-sanity-tests/commons/results_analyzer.py
+++ b/fiware-region-sanity-tests/commons/results_analyzer.py
@@ -79,6 +79,7 @@ class ResultAnalyzer(object):
                 elif child_node_list[0].localName == CHILD_NODE_SKIP:
                     status = TEST_STATUS_SKIP
 
+            # Filter out "regular" test cases (...test_<region>.TestSuite)
             testclass = testcase.getAttribute('classname')
             if re.match(".*\.test_.+\.TestSuite$", testclass):
                 testpackage = testclass.split(".")[-2]


### PR DESCRIPTION
#### Reviewers

@jframos 
#### Description

This PR is related to #181 and solves an error in a regular expression.
#### Testing

Verified with sample "valid.xml" xUnit report attached to the bug.
