### PR TITLE
Add operation to get the list of shared networks and select the one to use in E2E tests

### DIFF
--- a/fiware-region-sanity-tests/README.rst
+++ b/fiware-region-sanity-tests/README.rst
@@ -236,6 +236,7 @@ Apart from the former data, it is also possible to provide some per-region
 configuration values under ``region_configuration``:
 
 - ``external_network_name`` is the network for external floating IP addresses
+- ``shared_network_name`` is the shared network to use in E2E tests
 - ``test_flavor`` specifies the flavor of instances launched in tests
 - ``test_image`` specifies the base image of instances launched in tests
 
@@ -274,6 +275,10 @@ are required:
             "external_network_name": {
                 "Region1": "public-ext-net-01",
                 "Region2": "my-ext-net",
+                ...
+            },
+            "shared_network_name": {
+                "Region3": "my-shared-net",
                 ...
             },
             "test_flavor": {

--- a/fiware-region-sanity-tests/doc/publish_status_and_test_data.rst
+++ b/fiware-region-sanity-tests/doc/publish_status_and_test_data.rst
@@ -26,7 +26,7 @@ Here is an example of the generated ``test_results.txt`` for an specific region
 
 ::
 
-    [Tests: 26, Errors: 0, Failures: 0, Skipped: 0]
+    [Tests: 28, Errors: 0, Failures: 0, Skipped: 0]
 
     REGION GLOBAL STATUS
 
@@ -55,15 +55,17 @@ Here is an example of the generated ``test_results.txt`` for an specific region
       N/A	 test_create_text_object_and_download_it_from_container
       OK	 test_delete_an_object_from_a_container
       OK	 test_delete_container
-      OK	 test_deploy_instance_with_network_and_associate_public_ip
-      OK	 test_deploy_instance_with_networks_and_check_metadata_service
-      OK	 test_deploy_instance_with_networks_and_e2e_connection_using_public_ip
-      OK	 test_deploy_instance_with_networks_and_e2e_snat_connection
       OK	 test_deploy_instance_with_new_network
       OK	 test_deploy_instance_with_new_network_and_all_params
+      OK	 test_deploy_instance_with_new_network_and_associate_public_ip
+      OK	 test_deploy_instance_with_new_network_and_check_metadata_service
+      OK	 test_deploy_instance_with_new_network_and_e2e_connection_using_public_ip
+      OK	 test_deploy_instance_with_new_network_and_e2e_snat_connection
       OK	 test_deploy_instance_with_new_network_and_keypair
       OK	 test_deploy_instance_with_new_network_and_metadata
       OK	 test_deploy_instance_with_new_network_and_sec_group
+      OK	 test_deploy_instance_with_shared_network_and_e2e_connection_using_public_ip
+      OK	 test_deploy_instance_with_shared_network_and_e2e_snat_connection
       OK	 test_external_networks
       OK	 test_flavors_not_empty
       OK	 test_images_not_empty

--- a/fiware-region-sanity-tests/doc/test_cases.rst
+++ b/fiware-region-sanity-tests/doc/test_cases.rst
@@ -63,11 +63,11 @@ These Test Cases will be common for all federated regions.
   public IP and establish a SSH connection
 * Test whether it is possible to deploy an instance with a new network
   and connect to the internet (SNAT) without assigning a public IP
-* Test whether it is possible to deploy an instance using the existing shared
+* Test whether it is possible to deploy an instance using an existing shared
   network and connect to the internet (SNAT) without assigning a public IP
 * Test whether it is possible to deploy an instance with a new network
   and check that metadata service is working properly (PhoneHome service)
-* Test whether it is possible to deploy an instance using the exiting shared
+* Test whether it is possible to deploy an instance using an exiting shared
   network and check that metadata service is working properly
 
 **Regions without an OpenStack network service**

--- a/fiware-region-sanity-tests/tests/fiware_region_with_networks_tests.py
+++ b/fiware-region-sanity-tests/tests/fiware_region_with_networks_tests.py
@@ -162,10 +162,18 @@ class FiwareRegionWithNetworkTest(FiwareRegionsBaseTests):
         HELPER. Finds and returns the shared network name of current region
         :return: Shared network name
         """
-        shared_network_name = TEST_SHARED_NET_DEFAULT
+        # get from settings the name of the shared network to lookup
+        lookup_network_name = TEST_SHARED_NET_DEFAULT
         shared_network_conf = self.conf[PROPERTIES_CONFIG_REGION].get(PROPERTIES_CONFIG_REGION_SHARED_NET)
         if shared_network_conf:
-            shared_network_name = shared_network_conf.get(self.region_name, TEST_SHARED_NET_DEFAULT)
+            lookup_network_name = shared_network_conf.get(self.region_name, TEST_SHARED_NET_DEFAULT)
+
+        # find the network in the list of existing shared networks
+        lookup_network_list = self.neutron_operations.find_networks(name=lookup_network_name,
+                                                                    shared=True,
+                                                                    router_external=False)
+        shared_network_name = lookup_network_list[0]['name'] if lookup_network_list else None
+        self.assertIsNotNone(shared_network_name, "No shared network %s found" % lookup_network_name)
 
         return shared_network_name
 


### PR DESCRIPTION
#### Reviewers

@flopezag @jframos
#### Description

This provides the feature described in task 5096 (retrieve the list of shared networks and get the one to work with, as given by settings). If no name of shared network is provided in settings file, a default value "shared-net" is used.
#### Testing

Verified in CI environment with region Spain2.
