### PR TITLE
[Story/CLAUDIA-5615] Add/Update elapsed time as context attribute of the region

### DIFF
--- a/fiware-region-sanity-tests/README.rst
+++ b/fiware-region-sanity-tests/README.rst
@@ -309,7 +309,7 @@ the *key_test_cases* and *opt_test_cases* information configured in the
 ``resources/settings.json`` file.
 
 Take a look at `Sanity Status and Data Storage documentation
-<doc/status_and_data_storage.rst>`_ to know more about *Sanity and Test Status*
+<doc/publish_status_and_test_data.rst>`_ to know more about *Sanity and Test Status*
 and the Context Broker integration with *FiHealth - Sanity Checks*
 
 

--- a/fiware-region-sanity-tests/doc/publish_status_and_test_data.rst
+++ b/fiware-region-sanity-tests/doc/publish_status_and_test_data.rst
@@ -77,7 +77,7 @@ Elapsed execution time of Sanity Checks
 Apart from the context attributes described above, when Sanity Cheks
 of a node have been executed from Jenkins, a new attribute is updated in the
 context information of that region: the elapsed time of the execution
-``sanity_checks_elapsed_time``. This attribute will have the time in
+``sanity_check_elapsed_time``. This attribute will have the time in
 milliseconds or 'N/A' if Sanity tests have not finished yet.
 
 

--- a/fiware-region-sanity-tests/doc/publish_status_and_test_data.rst
+++ b/fiware-region-sanity-tests/doc/publish_status_and_test_data.rst
@@ -74,9 +74,9 @@ Here is an example of the generated ``test_results.txt`` for an specific region
 Elapsed execution time of Sanity Checks
 ---------------------------------------
 
-Apart from the context attributes described above, when Sanity Cheks
-of a node have been executed from Jenkins, a new attribute is updated in the
-context information of that region: the elapsed time of the execution
+Apart from the context attributes described above, when Sanity Checks
+have been executed from Jenkins, a new attribute is updated in the
+context information of the region: the elapsed time of the execution
 ``sanity_check_elapsed_time``. This attribute will have the time in
 milliseconds or 'N/A' if Sanity tests have not finished yet.
 

--- a/fiware-region-sanity-tests/doc/publish_status_and_test_data.rst
+++ b/fiware-region-sanity-tests/doc/publish_status_and_test_data.rst
@@ -71,6 +71,16 @@ Here is an example of the generated ``test_results.txt`` for an specific region
       OK	 test_images_not_empty
 
 
+Elapsed execution time of Sanity Checks
+---------------------------------------
+
+Apart from the context attributes described above, when Sanity Cheks
+of a node have been executed from Jenkins, a new attribute is updated in the
+context information of that region: the elapsed time of the execution
+``sanity_checks_elapsed_time``. This attribute will have the time in
+milliseconds or 'N/A' if Sanity tests have not finished yet.
+
+
 Sanity Check Status and Test Execution Status
 ---------------------------------------------
 


### PR DESCRIPTION
#### Reviewers

@jesuspg @pratid 
#### Description

The elapsed time information is calculated by the own script executed on Jenkins because the 'duration' of the Jenkins' job only can be consulted when it has finished. To avoid retrieving this data from the Dasboard and reduce the necessary logic, the measure of this time will be performed by the script. This way this attribute will be stored as a context attribute to be consulted by anyone.
#### Testing

Locally and Jenkins.
