### PR TITLE
Fix problem when spawning a new process from within a Jenkins job

### DIFF
--- a/fiware-region-sanity-tests/resources/jenkins/FIHealth-SanityCheck-0-RestartTestServers.xml
+++ b/fiware-region-sanity-tests/resources/jenkins/FIHealth-SanityCheck-0-RestartTestServers.xml
@@ -26,7 +26,10 @@ This job forces the restart of supporting servers used in Sanity Check execution
   <customWorkspace>$FIHEALTH_WORKSPACE</customWorkspace>
   <builders>
     <hudson.tasks.Shell>
-      <command># Execute &apos;restart&apos; script
+      <command># Workaround to spawn processes from build (https://wiki.jenkins-ci.org/display/JENKINS/Spawning+processes+from+build)
+BUILD_ID=dontKillMe
+
+# Execute &apos;restart&apos; script
 ./$FIHEALTH_SANITY_PROJECT/resources/scripts/jenkins.sh restart
 </command>
     </hudson.tasks.Shell>

--- a/fiware-region-sanity-tests/resources/jenkins/FIHealth-SanityCheck-0-SetUp.xml
+++ b/fiware-region-sanity-tests/resources/jenkins/FIHealth-SanityCheck-0-SetUp.xml
@@ -46,7 +46,10 @@ This job performs the initial setup procedure for Sanity Check execution&#xd;
   <customWorkspace>$FIHEALTH_WORKSPACE</customWorkspace>
   <builders>
     <hudson.tasks.Shell>
-      <command># Execute &apos;setup&apos; script
+      <command># Workaround to spawn processes from build (https://wiki.jenkins-ci.org/display/JENKINS/Spawning+processes+from+build)
+BUILD_ID=dontKillMe
+
+# Execute &apos;setup&apos; script
 ./$FIHEALTH_SANITY_PROJECT/resources/scripts/jenkins.sh setup
 </command>
     </hudson.tasks.Shell>

--- a/fiware-region-sanity-tests/resources/logging.conf
+++ b/fiware-region-sanity-tests/resources/logging.conf
@@ -9,17 +9,17 @@ keys=consoleFormatter,fileFormatter
 
 [logger_root]
 level=DEBUG
-handlers=consoleHandler,fileHandler
+handlers=consoleHandler
 
 [logger_HttpPhoneHomeServer]
 level=DEBUG
-handlers=consoleHandler,fileHandler
+handlers=consoleHandler
 qualname=HttpPhoneHomeServer
 propagate=0
 
 [handler_consoleHandler]
 class=StreamHandler
-level=ERROR
+level=DEBUG
 formatter=consoleFormatter
 args=(sys.stdout,)
 
@@ -30,7 +30,7 @@ formatter=fileFormatter
 args=('/var/log/httpPhoneHomeServer.log', 'w')
 
 [formatter_consoleFormatter]
-format=-   %(asctime)s - %(name)s - %(levelname)s - %(message)s
+format=%(asctime)s - %(name)s - %(levelname)s - %(message)s
 datefmt=
 
 [formatter_fileFormatter]

--- a/fiware-region-sanity-tests/resources/scripts/jenkins.sh
+++ b/fiware-region-sanity-tests/resources/scripts/jenkins.sh
@@ -219,11 +219,12 @@ function change_status() {
 # This function restarts PhoneHome server used for tests
 function restart_phone_home_server() {
 	local signal=TERM
-	local logfile=/var/log/httpPhoneHomeServerRequests.log
+	local logfile=/var/log/httpPhoneHomeServer.log
 	[ "$1" == "--force" ] && signal=KILL
 	pushd $PROJECT_DIR >/dev/null
 	pkill -$signal -f http_phonehome_server
-	PYTHONPATH=. nohup python2.7 commons/http_phonehome_server.py > $logfile &
+	export PYTHONPATH=$PWD
+	nohup python2.7 commons/http_phonehome_server.py > $logfile 2>&1 &
 	popd >/dev/null
 }
 


### PR DESCRIPTION
#### Reviewers

@jframos 
#### Description

Use a workaround (suggested by Jenkins CI documentation) to keep PhoneHome server running after the job has finished.
#### Testing

Verified in local Jenkins CI
