### PR TITLE
big files are downloaded just in the first execution

### DIFF
--- a/fiware-region-sanity-tests/tests/fiware_region_object_storage_tests.py
+++ b/fiware-region-sanity-tests/tests/fiware_region_object_storage_tests.py
@@ -32,6 +32,7 @@ from swiftclient.exceptions import ClientException as SwiftClientException
 from datetime import datetime
 import hashlib
 import urllib2
+import os
 
 
 class FiwareRegionsObjectStorageTests(FiwareRegionsBaseTests):
@@ -161,7 +162,7 @@ class FiwareRegionsObjectStorageTests(FiwareRegionsBaseTests):
 
         suffix = datetime.utcnow().strftime('%Y%m%d%H%M%S%m')
         containerName = self.region_name + TEST_CONTAINER_PREFIX + suffix
-        big_object_name = self.region_name + TEST_BIG_OBJECT_PREFIX + suffix + TEST_BIG_FILE_EXTENSION
+        big_object_name = TEST_BIG_OBJECT_PREFIX + TEST_BIG_FILE_EXTENSION
         remote_big_object_name = self.region_name + TEST_BIG_OBJECT_REMOTE_PREFIX + TEST_BIG_OBJECT_PREFIX + suffix \
                                  + TEST_BIG_FILE_EXTENSION
 
@@ -170,17 +171,18 @@ class FiwareRegionsObjectStorageTests(FiwareRegionsBaseTests):
         self.test_world['containers'].append(containerName)
         self.logger.debug("Created %s container was created", containerName)
 
-        # Creating a new big object
-        big_file_url_1 = self.conf[PROPERTIES_CONFIG_TEST][PROPERTIES_CONFIG_SWIFT][PROPERTIES_CONFIG_SWIFT_BIG_FILE_1]
-        f = urllib2.urlopen(big_file_url_1)
-        data = f.read()
-        try:
-            with open(SWIFT_RESOURCES_PATH + big_object_name, "wb") as code:
-                code.write(data)
-        except IOError:
-            self.logger.error("Error while writing %s file", SWIFT_RESOURCES_PATH + big_object_name)
+        # Creating a new big object if do not exits
+        if not os.path.isfile(SWIFT_RESOURCES_PATH + big_object_name):
+            big_file_url_1 = \
+                self.conf[PROPERTIES_CONFIG_TEST][PROPERTIES_CONFIG_SWIFT][PROPERTIES_CONFIG_SWIFT_BIG_FILE_1]
+            f = urllib2.urlopen(big_file_url_1)
+            data = f.read()
 
-        self.test_world['local_objects'].append(big_object_name)
+            try:
+                with open(SWIFT_RESOURCES_PATH + big_object_name, "wb") as code:
+                        code.write(data)
+            except IOError:
+                self.logger.error("Error while writing %s file", SWIFT_RESOURCES_PATH + big_object_name)
 
         # Uploading the object
         response = self.swift_operations.create_object(containerName, SWIFT_RESOURCES_PATH
@@ -190,8 +192,8 @@ class FiwareRegionsObjectStorageTests(FiwareRegionsBaseTests):
                           .read()).hexdigest()
 
         self.assertIsNotNone(response, "Object could not be created")
-        self.test_world['swift_objects'].append(containerName + "/" + big_object_name)
-        self.logger.debug("Created %s object was created", big_object_name)
+        self.test_world['swift_objects'].append(containerName + "/" + remote_big_object_name)
+        self.logger.debug("Created %s object with name %s", big_object_name, remote_big_object_name)
 
         # Downloading the object
         response = self.swift_operations.get_object(containerName, remote_big_object_name,
@@ -205,18 +207,19 @@ class FiwareRegionsObjectStorageTests(FiwareRegionsBaseTests):
         self.assertEqual(originHash, remoteHash, "The original file and the downloaded file are different")
 
         # Downloading a second big file to check that is different
-        suffix2 = datetime.utcnow().strftime('%Y%m%d%H%M%S%m')
-        big_file_url_2 = self.conf[PROPERTIES_CONFIG_TEST][PROPERTIES_CONFIG_SWIFT][PROPERTIES_CONFIG_SWIFT_BIG_FILE_2]
-        f2 = urllib2.urlopen(big_file_url_2)
-        data = f2.read()
-        try:
-            with open(SWIFT_RESOURCES_PATH + TEST_BIG_OBJECT_PREFIX + suffix2 + TEST_BIG_FILE_EXTENSION, "wb") as code2:
-                code2.write(data)
-        except IOError:
-            self.logger.error("Error while writing %s file", SWIFT_RESOURCES_PATH + TEST_BIG_OBJECT_PREFIX +
-                              suffix2 + TEST_BIG_FILE_EXTENSION)
-
-        self.test_world['local_objects'].append(TEST_BIG_OBJECT_PREFIX + suffix2 + TEST_BIG_FILE_EXTENSION)
+        if not os.path.isfile(SWIFT_RESOURCES_PATH + big_object_name):
+            suffix2 = "second_file"
+            big_file_url_2 = \
+                self.conf[PROPERTIES_CONFIG_TEST][PROPERTIES_CONFIG_SWIFT][PROPERTIES_CONFIG_SWIFT_BIG_FILE_2]
+            f2 = urllib2.urlopen(big_file_url_2)
+            data = f2.read()
+            try:
+                with open(SWIFT_RESOURCES_PATH + TEST_BIG_OBJECT_PREFIX + suffix2 +
+                                  TEST_BIG_FILE_EXTENSION, "wb") as code2:
+                    code2.write(data)
+            except IOError:
+                self.logger.error("Error while writing %s file", SWIFT_RESOURCES_PATH + TEST_BIG_OBJECT_PREFIX +
+                                  suffix2 + TEST_BIG_FILE_EXTENSION)
 
         # Checking that two different files generates are different
         origin2 = hashlib.md5(open(SWIFT_RESOURCES_PATH + TEST_BIG_OBJECT_PREFIX + suffix2 + TEST_BIG_FILE_EXTENSION,


### PR DESCRIPTION
### REVIEWERS

@jframos 
### DESCRIPTION
- big files are downloaded just in the first execution to prevent others could remove it in future executions.
