### PR TITLE
Get nova console logs from VMs and write them to a separate file

### DIFF
--- a/fiware-region-sanity-tests/README.rst
+++ b/fiware-region-sanity-tests/README.rst
@@ -308,15 +308,14 @@ additionally an HTML report ``test_results.html`` (or the same basename as
 the former) is generated from the given template (or the default found at
 ``resources/templates/`` folder).
 
-Apart from these, a log file will be written with all logged info in a
+Additionally, a log file is written with all logged info in a
 Sanity Check execution, based on its handlers configuration
 (`resources/logging_sanitychecks.conf`). When test cases involve VM
 launching, just before deleting the VM, *FIHealth Sanity Checks*
-will try to get the Nova Console-Log of that VM and it will write
-the content in a new file `novaconsole_{region_name}_{server_id}.log`.
-If the Console-Log is empty or it was impossible to be retrieved,
-the file will not be generated. These files are only generated whether
-the log level is set tu *DEBUG*.
+tries to get the Nova Console-Log of that VM and it writes
+the content in a new file `test_novaconsole_{region_name}_{server_id}.log`.
+If the Console-Log is empty, it was impossible to be retrieved or
+the log level is set tu *DEBUG*, the file is not generated.
 
 The script ``commons/result_analyzer.py`` is invoked to create a summary
 report ``test_results.txt``. It will analyze the status of each region using

--- a/fiware-region-sanity-tests/README.rst
+++ b/fiware-region-sanity-tests/README.rst
@@ -308,6 +308,16 @@ additionally an HTML report ``test_results.html`` (or the same basename as
 the former) is generated from the given template (or the default found at
 ``resources/templates/`` folder).
 
+Apart from these, a log file will be written with all logged info in a
+Sanity Check execution, based on its handlers configuration
+(`resources/logging_sanitychecks.conf`). When test cases involve VM
+launching, just before deleting the VM, *FIHealth Sanity Checks*
+will try to get the Nova Console-Log of that VM and it will write
+the content in a new file `novaconsole_{region_name}_{server_id}.log`.
+If the Console-Log is empty or it was impossible to be retrieved,
+the file will not be generated. These files are only generated whether
+the log level is set tu *DEBUG*.
+
 The script ``commons/result_analyzer.py`` is invoked to create a summary
 report ``test_results.txt``. It will analyze the status of each region using
 the *key_test_cases* and *opt_test_cases* information configured in the

--- a/fiware-region-sanity-tests/commons/constants.py
+++ b/fiware-region-sanity-tests/commons/constants.py
@@ -25,6 +25,7 @@
 # LOGGING CONFIGURATION
 LOGGING_FILE_PHONEHOME = "resources/logging_phonehome.conf"
 LOGGING_FILE_SANITYCHECKS = "resources/logging_sanitychecks.conf"
+LOGGING_OUTPUT_NOVA_CONSOLE_LOG_TEMPLATE = "test_novaconsole_{region_name}_{server_id}.log"
 
 # CONFIGURATION PROPERTIES
 PROPERTIES_FILE = "resources/settings.json"

--- a/fiware-region-sanity-tests/commons/fiware_cloud_test_case.py
+++ b/fiware-region-sanity-tests/commons/fiware_cloud_test_case.py
@@ -235,9 +235,22 @@ class FiwareTestCase(unittest.TestCase):
         # release resources to ensure a clean world
         for server_id in list(world['servers']):
             try:
-                # Logging nova console-log of the server before deleting
-                cls.logger.debug("Nova Console-Log of the server '%s':\n %s",
-                                 server_id, cls.nova_operations.get_nova_console_log(server_id))
+                # Logging Nova Console-Log of the server before deleting and writing data into a new file.
+                # Nova Console-Log is only retrieved when log level for Sanity Checks is set to DEBUG.
+                if cls.logger_level == 'DEBUG':
+                    nova_console_log = cls.nova_operations.get_nova_console_log(server_id)
+                    nova_console_file_name = \
+                        LOGGING_OUTPUT_NOVA_CONSOLE_LOG_TEMPLATE.format(region_name=cls.region_name,
+                                                                        server_id=server_id)
+                    if nova_console_log:
+                        nova_console_file = open(nova_console_file_name, 'w')
+                        nova_console_file.write(nova_console_log)
+                        nova_console_file.close()
+                        cls.logger.debug("Nova Console-Log of the server '%s' has been saved in '%s'",
+                                         server_id, nova_console_file_name)
+                    else:
+                        cls.logger.debug("Nova Console-Log of the server '%s' is empty",
+                                         server_id)
 
                 # Deleting server
                 cls.nova_operations.delete_server(server_id)
@@ -470,6 +483,7 @@ class FiwareTestCase(unittest.TestCase):
             config.get('sanitychecks_handler_fileHandler', 'filename').format(region_name=cls.region_name), mode='w')
         file_handler.setFormatter(log_formatter)
         file_handler.setLevel(config.get('sanitychecks_handler_fileHandler', 'level'))
+        cls.logger_level = config.get('sanitychecks_handler_fileHandler', 'level')
 
         # > Set FileHandler for default root logger and configure UTC time formatter
         logging.getLogger('').addHandler(file_handler)

--- a/fiware-region-sanity-tests/commons/fiware_cloud_test_case.py
+++ b/fiware-region-sanity-tests/commons/fiware_cloud_test_case.py
@@ -240,7 +240,7 @@ class FiwareTestCase(unittest.TestCase):
                 if cls.logger_level == 'DEBUG':
                     nova_console_log = cls.nova_operations.get_nova_console_log(server_id)
                     nova_console_file_name = \
-                        LOGGING_OUTPUT_NOVA_CONSOLE_LOG_TEMPLATE.format(region_name=cls.region_name,
+                        LOGGING_OUTPUT_NOVA_CONSOLE_LOG_TEMPLATE.format(region_name=cls.region_name.lower(),
                                                                         server_id=server_id)
                     if nova_console_log:
                         nova_console_file = open(nova_console_file_name, 'w')

--- a/fiware-region-sanity-tests/commons/fiware_cloud_test_case.py
+++ b/fiware-region-sanity-tests/commons/fiware_cloud_test_case.py
@@ -235,6 +235,11 @@ class FiwareTestCase(unittest.TestCase):
         # release resources to ensure a clean world
         for server_id in list(world['servers']):
             try:
+                # Logging nova console-log of the server before deleting
+                cls.logger.debug("Nova Console-Log of the server '%s':\n %s",
+                                 server_id, cls.nova_operations.get_nova_console_log(server_id))
+
+                # Deleting server
                 cls.nova_operations.delete_server(server_id)
                 cls.nova_operations.wait_for_task_status(server_id, 'DELETED')
             except NotFound:

--- a/fiware-region-sanity-tests/commons/nova_operations.py
+++ b/fiware-region-sanity-tests/commons/nova_operations.py
@@ -308,3 +308,12 @@ class FiwareNovaOperations:
         :return: None
         """
         self.client.servers.add_floating_ip(server_id, ip_address, fixed_address=None)
+
+    def get_nova_console_log(self, server_id):
+        """
+        This method gets the NOVA Console-Log of the given server.
+        :param server_id (string): Server ID to get its console-log
+        :return (string): console-log output
+        """
+
+        return self.client.servers.get_console_output(server_id)

--- a/fiware-region-sanity-tests/sanity_checks
+++ b/fiware-region-sanity-tests/sanity_checks
@@ -141,7 +141,12 @@ done
 }
 TESTS=${TESTS:-tests/regions}
 
-# Main
+# Delete all generated log files before each sanity check execution.
+echo "Deleting log files from previous executions"
+rm -f *.log
+
+# Sanity Checks execution
+echo "Running Sanity Checks"
 nosetests $TESTS $NOSEOPTS -v --exe \
 	--with-xunit --xunit-file=$OUTPUT_NAME.xml \
 	--with-html --html-report=$OUTPUT_NAME.html \

--- a/fiware-region-sanity-tests/sanity_checks
+++ b/fiware-region-sanity-tests/sanity_checks
@@ -95,7 +95,7 @@ REGIONS=$(sed -n '/"external_network_name"/,/}/ p' resources/settings.json \
 REGIONS_PATTERN='^\('$(echo $REGIONS | sed 's/ /\\|/g')'\)$'
 
 # Process command line
-REGION_NAME_LIST=()
+REGION_NAME_LIST=
 OPTERR=
 OPTSTR=$(echo :-:$OPTS | sed 's/([a-zA-Z0-9]*)//g')
 OPTHLP=$(sed -n '20,/^$/ { s/$0/'$NAME'/; s/^#[ ]\?//p }' $0 | head -n -2;
@@ -132,7 +132,7 @@ while [ -z "$OPTERR" -a -n "$1" ]; do
 	REGION=$(expr "$1" : "$REGIONS_PATTERN" | sed 's/.*/\L&/')
 	[ -z "$REGION" ] && OPTERR="Invalid region '$1'"
 	TESTS="$TESTS tests.regions.test_$REGION"
-	REGION_NAME_LIST+=($REGION)
+	REGION_NAME_LIST="$REGION_NAME_LIST $REGION"
 	shift
 done
 [ -n "$OPTERR" ] && {
@@ -145,8 +145,8 @@ done
 TESTS=${TESTS:-tests/regions}
 
 # Delete all generated Nova Console-Log files for the given regions before each sanity check execution.
-echo "Deleting Nova Console-Log files from previous executions for the given regions (${REGION_NAME_LIST[@]})"
-for region in ${REGION_NAME_LIST[@]}; do
+echo "Deleting Nova Console-Log files from previous executions for the given regions ($REGION_NAME_LIST)"
+for region in $REGION_NAME_LIST; do
 	rm -f ${OUTPUT_NOVA_CONSOLE_NAME}_${region}_*.log
 done
 

--- a/fiware-region-sanity-tests/sanity_checks
+++ b/fiware-region-sanity-tests/sanity_checks
@@ -95,6 +95,7 @@ REGIONS=$(sed -n '/"external_network_name"/,/}/ p' resources/settings.json \
 REGIONS_PATTERN='^\('$(echo $REGIONS | sed 's/ /\\|/g')'\)$'
 
 # Process command line
+REGION_NAME_LIST=()
 OPTERR=
 OPTSTR=$(echo :-:$OPTS | sed 's/([a-zA-Z0-9]*)//g')
 OPTHLP=$(sed -n '20,/^$/ { s/$0/'$NAME'/; s/^#[ ]\?//p }' $0 | head -n -2;
@@ -131,6 +132,7 @@ while [ -z "$OPTERR" -a -n "$1" ]; do
 	REGION=$(expr "$1" : "$REGIONS_PATTERN" | sed 's/.*/\L&/')
 	[ -z "$REGION" ] && OPTERR="Invalid region '$1'"
 	TESTS="$TESTS tests.regions.test_$REGION"
+	REGION_NAME_LIST+=($REGION)
 	shift
 done
 [ -n "$OPTERR" ] && {
@@ -142,10 +144,9 @@ done
 }
 TESTS=${TESTS:-tests/regions}
 
-# Delete all generated log files for the given regions before each sanity check execution.
-echo "Deleting log files from previous executions for the given regions ($1)"
-for region in $(echo $1 | sed "s/,/ /g")
-do
+# Delete all generated Nova Console-Log files for the given regions before each sanity check execution.
+echo "Deleting Nova Console-Log files from previous executions for the given regions (${REGION_NAME_LIST[@]})"
+for region in ${REGION_NAME_LIST[@]}; do
 	rm -f ${OUTPUT_NOVA_CONSOLE_NAME}_${region}_*.log
 done
 

--- a/fiware-region-sanity-tests/sanity_checks
+++ b/fiware-region-sanity-tests/sanity_checks
@@ -78,6 +78,7 @@ END`
 # Command line options (default values)
 OUTPUT_NAME=test_results
 TEMPLATE_NAME=test_report_template.html
+OUTPUT_NOVA_CONSOLE_NAME=test_novaconsole
 
 # Environment variables for nosetests
 export TEST_PHONEHOME_ENDPOINT
@@ -141,9 +142,12 @@ done
 }
 TESTS=${TESTS:-tests/regions}
 
-# Delete all generated log files before each sanity check execution.
-echo "Deleting log files from previous executions"
-rm -f *.log
+# Delete all generated log files for the given regions before each sanity check execution.
+echo "Deleting log files from previous executions for the given regions ($1)"
+for region in $(echo $1 | sed "s/,/ /g")
+do
+	rm -f ${OUTPUT_NOVA_CONSOLE_NAME}_${region}_*.log
+done
 
 # Sanity Checks execution
 echo "Running Sanity Checks"


### PR DESCRIPTION
#### Reviewers

@flopezag @pratid 
#### Description

This PR is about _CLAUDIA-5789_.
Nova Console-Log will be written only in logger file (DEBUG) before deleting VMs generated by each sanity test. This information will not be shown on Dashboard Test Details page, only in the logger file.
#### Testing

Locally (Spain2, Prague)
