### PR TITLE
Change log messages when receiving phonehome signals

### DIFF
--- a/fiware-region-sanity-tests/commons/dbus_phonehome_service.py
+++ b/fiware-region-sanity-tests/commons/dbus_phonehome_service.py
@@ -79,18 +79,20 @@ class DbusPhoneHomeClient():
          main loop will be finished.
         :return: None
         """
-        DbusPhoneHomeClient.logger.debug("Signal received with data '%s'", phonehome_http_data)
+        DbusPhoneHomeClient.logger.debug("Data received from PhoneHome Server: '%s'",
+                                         phonehome_http_data.encode('base64', 'strict'))
         hostname = re.match(".*hostname=([\w-]*)", phonehome_http_data)
         hostname = hostname.group(1) if hostname is not None else hostname
-        DbusPhoneHomeClient.logger.debug("Received hostname: '%s'. Expected hostname: '%s'",
-                                             hostname, DbusPhoneHomeClient.expected_signal_hostname)
         if DbusPhoneHomeClient.expected_signal_hostname == hostname:
-            DbusPhoneHomeClient.logger.debug("Matches! Finishing main loop...")
+            DbusPhoneHomeClient.logger.debug("Received hostname: '%s'",
+                                             DbusPhoneHomeClient.expected_signal_hostname)
             DbusPhoneHomeClient.data_received = phonehome_http_data
             DbusPhoneHomeClient.mainloop.quit()
         else:
-            DbusPhoneHomeClient.logger.debug("Signal data received is not the expected one. "
-                                             "Waiting for valid signal...")
+            DbusPhoneHomeClient.logger.debug("Received data are not for this FIWARE Node. "
+                                             "Probably they come from another SanityCheck execution running "
+                                             "at the same time. Skipping and waiting for more data from PhoneHome "
+                                             "Server...")
 
     @staticmethod
     def phonehome_signal_handler_metadata(phonehome_http_data, hostname):
@@ -101,16 +103,18 @@ class DbusPhoneHomeClient():
          main loop will be finished.
         :return: None
         """
-        DbusPhoneHomeClient.logger.debug("Received hostname: '%s'. Expected hostname: '%s'",
-                                         hostname, DbusPhoneHomeClient.expected_signal_hostname)
+        DbusPhoneHomeClient.logger.debug("Data received from PhoneHome Server (Hostname): '%s'",
+                                         hostname.encode('base64', 'strict'))
 
         if DbusPhoneHomeClient.expected_signal_hostname == hostname:
-            DbusPhoneHomeClient.logger.debug("Matches! Finishing main loop...")
+            DbusPhoneHomeClient.logger.debug("Received hostname: '%s'", hostname)
             DbusPhoneHomeClient.data_received = phonehome_http_data
             DbusPhoneHomeClient.mainloop.quit()
         else:
-            DbusPhoneHomeClient.logger.debug("Signal hostname received is not the expected one. "
-                                             "Waiting for valid signal...")
+            DbusPhoneHomeClient.logger.debug("Received data are not for this FIWARE Node. "
+                                             "Probably they come from another SanityCheck execution running "
+                                             "at the same time. Skipping and waiting for more data from PhoneHome "
+                                             "Server...")
 
     def connect_and_wait_for_phonehome_signal(self, bus_name, object_path, phonehome_signal, data_expected):
         """

--- a/fiware-region-sanity-tests/commons/dbus_phonehome_service.py
+++ b/fiware-region-sanity-tests/commons/dbus_phonehome_service.py
@@ -80,7 +80,7 @@ class DbusPhoneHomeClient():
         :return: None
         """
         DbusPhoneHomeClient.logger.debug("Data received from PhoneHome Server: '%s'",
-                                         phonehome_http_data.encode('base64', 'strict'))
+                                         phonehome_http_data.encode('base64', 'strict').replace('\n', ' '))
         hostname = re.match(".*hostname=([\w-]*)", phonehome_http_data)
         hostname = hostname.group(1) if hostname is not None else hostname
         if DbusPhoneHomeClient.expected_signal_hostname == hostname:
@@ -104,7 +104,7 @@ class DbusPhoneHomeClient():
         :return: None
         """
         DbusPhoneHomeClient.logger.debug("Data received from PhoneHome Server (Hostname): '%s'",
-                                         hostname.encode('base64', 'strict'))
+                                         hostname.encode('base64', 'strict').replace('\n', ' '))
 
         if DbusPhoneHomeClient.expected_signal_hostname == hostname:
             DbusPhoneHomeClient.logger.debug("Received hostname: '%s'", hostname)


### PR DESCRIPTION
#### Reviewers

@pratid @flopezag 
#### Description

Change log messages when detecting signals in the bus (E2E tests).
The data received from PhoneHome server is showd now under  _base64_ encoding to avoid the mix up.
Base64 is printed in the same line separated by white spaces.
#### Testing

Jenkins.
