### PR TITLE
Bug 5331: Check that DBus is registered on the system.

### DIFF
--- a/fiware-region-sanity-tests/commons/http_phonehome_server.py
+++ b/fiware-region-sanity-tests/commons/http_phonehome_server.py
@@ -54,7 +54,6 @@ class HttpPhoneHomeRequestHandler(BaseHTTPRequestHandler):
 
         transaction_id = "txid:" + self.headers['TransactionId']
 
-
         # Get data from body
         if content:
             if self.path == PHONEHOME_DBUS_OBJECT_METADATA_PATH:

--- a/fiware-region-sanity-tests/commons/nova_operations.py
+++ b/fiware-region-sanity-tests/commons/nova_operations.py
@@ -269,7 +269,8 @@ class FiwareNovaOperations:
                 break
 
             self.logger.debug("Waiting (#%d) for status %s of instance %s (current is %s)...",
-                              i+1, expected_status, server_id, server_data['status'])
+                              i + 1, expected_status, server_id, server_data['status'])
+
             time.sleep(SLEEP_TIME)
 
         self.logger.debug("Status of instance %s is %s", server_id, server_data['status'])

--- a/fiware-region-sanity-tests/commons/ssh_client.py
+++ b/fiware-region-sanity-tests/commons/ssh_client.py
@@ -90,7 +90,7 @@ class SSHClient():
         connected = False
         for i in range(MAX_WAIT_SSH_CONNECT_ITERATIONS):
             try:
-                self.logger.debug("Attempt (#%d) for SSH connection to %s", i+1, self.host)
+                self.logger.debug("Attempt (#%d) for SSH connection to %s", i + 1, self.host)
                 self.connect()
             except socket.error as e:
                 self.logger.debug("SSH connection error. Error: %s; Message: %s", str(e.strerror), str(e.message))

--- a/fiware-region-sanity-tests/tests/fiware_region_with_networks_tests.py
+++ b/fiware-region-sanity-tests/tests/fiware_region_with_networks_tests.py
@@ -578,6 +578,10 @@ class FiwareRegionWithNetworkTest(FiwareRegionsBaseTests):
 
         result = client.connect_and_wait_for_phonehome_signal(PHONEHOME_DBUS_NAME, PHONEHOME_DBUS_OBJECT_METADATA_PATH,
                                                               PHONEHOME_METADATA_SIGNAL, expected_instance_name)
+        
+        # First, check that the DBus is registered on the system
+        self.assertNotEqual(result, False, "PhoneHome bus or object not found. Please check the PhoneHome services.")
+
         self.assertIsNotNone(result, "PhoneHome request not received from VM '%s'" % server_id)
         self.logger.debug("Request received from VM when 'calling home': %s", result)
 

--- a/fiware-region-sanity-tests/tests/fiware_region_with_networks_tests.py
+++ b/fiware-region-sanity-tests/tests/fiware_region_with_networks_tests.py
@@ -578,7 +578,7 @@ class FiwareRegionWithNetworkTest(FiwareRegionsBaseTests):
 
         result = client.connect_and_wait_for_phonehome_signal(PHONEHOME_DBUS_NAME, PHONEHOME_DBUS_OBJECT_METADATA_PATH,
                                                               PHONEHOME_METADATA_SIGNAL, expected_instance_name)
-        
+
         # First, check that the DBus is registered on the system
         self.assertNotEqual(result, False, "PhoneHome bus or object not found. Please check the PhoneHome services.")
 


### PR DESCRIPTION
#### REVIEWERS

@jesuspg @pratid 
#### DESCRIPTION

Check that DBus is registered on the system and does not allow to send the message "argument of type 'bool' is not iterable"
#### TESTING

Locally testing in test environment the return of the False value and the correct operation of the test.
