### PR TITLE
Use a separate subscription to get sanity_status values

### DIFF
--- a/dashboard/.bumpversion.cfg
+++ b/dashboard/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.7.0
+current_version = 1.7.1
 commit = True
 tag = False
 

--- a/dashboard/bin/setup
+++ b/dashboard/bin/setup
@@ -90,10 +90,11 @@ eval `cd $BASEDIR; node -p <<-EOF
 	    util = require('util'),
 	    yaml = require('js-yaml'),
 	    config = yaml.safeLoad(fs.readFileSync('$CONFIG_FILE', 'utf8')),
-	    constants = require('./lib/constants');
-	var appUrl = url.format({
+	    constants = require('./lib/constants'),
+	    isLocalCB = config.cbroker.host.match(/127.0.0.1|localhost/);
+	var notifyBaseUrl = url.format({
 	    protocol: 'http',
-	    hostname: config.app.host,
+	    hostname: (isLocalCB) ? config.cbroker.host : config.app.host,
 	    port: config.app.port,
 	    pathname: config.app.webContext
 	});
@@ -105,8 +106,8 @@ eval `cd $BASEDIR; node -p <<-EOF
 	    EMAIL_FROM=%s',
 	    config.app.settings,
 	    config.cbroker.host, config.cbroker.port,
-	    appUrl, constants.CONTEXT_SANITY_STATUS_CHANGE,
-	    appUrl, constants.CONTEXT_SANITY_STATUS_VALUE,
+	    notifyBaseUrl, constants.CONTEXT_SANITY_STATUS_CHANGE,
+	    notifyBaseUrl, constants.CONTEXT_SANITY_STATUS_VALUE,
 	    config.mailman.emailFrom
 	);
 EOF`
@@ -164,14 +165,15 @@ rm -f $TMP_FILE
 # Subscriptions to Context Broker, if not existing yet
 # - ONCHANGE(sanity_status) to be notified ONLY for changes in sanity_status
 # - ONCHANGE(sanity_check_timestamp) to be notified for all new status values
-TRIGGER_CHANGE=sanity_status
-TRIGGER_VALUE=sanity_check_timestamp
-for TYPE in CHANGE VALUE; do
-	eval TRIGGER=\$TRIGGER_$TYPE
-	eval CALLBACK=\$CALLBACK_URL_$TYPE
+TRIGGER_ATTR_CHANGE=sanity_status
+TRIGGER_ATTR_VALUE=sanity_check_timestamp
+for TYPE in "CHANGE" "VALUE"; do
+	eval ATTR=\$TRIGGER_ATTR_$TYPE
+	eval REFERENCE=\$CALLBACK_URL_$TYPE
 	CSUB=$(mongo orion --quiet --eval \
-	'db.csubs.find({"conditions.value": "'$TRIGGER'"}).shellPrint();')
-	[ -n "$CSUB" ] || (curl $BROKER_URL/subscribeContext -s -S \
+	'db.csubs.find({"reference": "'$REFERENCE'"}).shellPrint();')
+	[ -n "$CSUB" ] || (echo "New CB subscription to \"$ATTR\" changes..."; \
+		curl $BROKER_URL/subscribeContext -s -S \
 		-H "Content-Type: application/json" \
 		-H "Accept: application/json" \
 		-X POST -d @- | python -mjson.tool) <<-EOF
@@ -184,15 +186,17 @@ for TYPE in CHANGE VALUE; do
 		        }
 		    ],
 		    "attributes": [
-		        "sanity_status"
+		        "sanity_status",
+		        "sanity_check_timestamp",
+		        "sanity_check_elapsed_time"
 		    ],
-		    "reference": "$CALLBACK",
+		    "reference": "$REFERENCE",
 		    "duration": "P99Y",
 		    "notifyConditions": [
 		        {
 		            "type": "ONCHANGE",
 		            "condValues": [
-		                "$TRIGGER"
+		                "$ATTR"
 		            ]
 		        }
 		    ],

--- a/dashboard/bin/setup
+++ b/dashboard/bin/setup
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-# Copyright 2015 Telefónica I+D
+# Copyright 2015-2016 Telefónica I+D
 # All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
@@ -85,18 +85,30 @@ fi
 
 # Parse config file to get settings file (region list) and endpoints
 eval `cd $BASEDIR; node -p <<-EOF
-	var yaml=require('js-yaml'), util=require('util'), fs=require('fs');
-	var config=yaml.safeLoad(fs.readFileSync('$CONFIG_FILE', 'utf8'));
+	var fs = require('fs'),
+	    url = require('url'),
+	    util = require('util'),
+	    yaml = require('js-yaml'),
+	    config = yaml.safeLoad(fs.readFileSync('$CONFIG_FILE', 'utf8')),
+	    constants = require('./lib/constants');
+	var appUrl = url.format({
+	    protocol: 'http',
+	    hostname: config.app.host,
+	    port: config.app.port,
+	    pathname: config.app.webContext
+	});
 	util.format('\
-	SETTINGS=%s \
-	CALLBACK_URL=http://%s:%s/%s/contextbroker \
-	BROKER_URL=http://%s:%s/NGSI10 \
-	EMAIL_FROM=%s',
-	config.app.settings,
-	config.app.host, config.app.port,
-	config.app.webContext.replace(/^\/|\/$/g, ''),
-	config.cbroker.host, config.cbroker.port,
-	config.mailman.emailFrom);
+	    SETTINGS=%s \
+	    BROKER_URL=http://%s:%s/NGSI10 \
+	    CALLBACK_URL_CHANGE=%s%s \
+	    CALLBACK_URL_VALUE=%s%s \
+	    EMAIL_FROM=%s',
+	    config.app.settings,
+	    config.cbroker.host, config.cbroker.port,
+	    appUrl, constants.CONTEXT_SANITY_STATUS_CHANGE,
+	    appUrl, constants.CONTEXT_SANITY_STATUS_VALUE,
+	    config.mailman.emailFrom
+	);
 EOF`
 if [ ! -r "$SETTINGS" ]; then
 	printf "Cannot find '%s' settings file\n" "$SETTINGS" 1>&2
@@ -116,7 +128,7 @@ LISTS=$(sed -n '/"external_network_name"/,/}/ { s/.*/\L&/; p}' $SETTINGS \
 ADMIN_MAIL=$EMAIL_FROM
 [ -n "$LISTS" -a -z "$ADMIN_PASS" ] && read -p "Admin password: " ADMIN_PASS
 
-# Create mailing lists
+# Create mailing lists not existing yet
 LANGUAGE='en'
 URL_HOST=$EMAIL_HOST
 TMP_FILE=/tmp/$NAME_$$
@@ -149,31 +161,42 @@ if echo $LIST | egrep -qv $EXCLUDE_LISTS; then
 fi
 rm -f $TMP_FILE
 
-# Subscribe to changes in Context Broker
-(curl $BROKER_URL/subscribeContext -s -S -X POST \
-	-H "Content-Type: application/json" -H "Accept: application/json" \
-	-d @- | python -mjson.tool) <<-EOF
-	{
-	    "entities": [
-	        {
-	            "type": "region",
-	            "isPattern": "true",
-	            "id": ".*"
-	        }
-	    ],
-	    "attributes": [
-	        "sanity_status"
-	    ],
-	    "reference": "$CALLBACK_URL",
-	    "duration": "P99Y",
-	    "notifyConditions": [
-	        {
-	            "type": "ONCHANGE",
-	            "condValues": [
-	                "sanity_status"
-	            ]
-	        }
-	    ],
-	    "throttling": "PT5S"
-	}
-EOF
+# Subscriptions to Context Broker, if not existing yet
+# - ONCHANGE(sanity_status) to be notified ONLY for changes in sanity_status
+# - ONCHANGE(sanity_check_timestamp) to be notified for all new status values
+TRIGGER_CHANGE=sanity_status
+TRIGGER_VALUE=sanity_check_timestamp
+for TYPE in CHANGE VALUE; do
+	eval TRIGGER=\$TRIGGER_$TYPE
+	eval CALLBACK=\$CALLBACK_URL_$TYPE
+	CSUB=$(mongo orion --quiet --eval \
+	'db.csubs.find({"conditions.value": "'$TRIGGER'"}).shellPrint();')
+	[ -n "$CSUB" ] || (curl $BROKER_URL/subscribeContext -s -S \
+		-H "Content-Type: application/json" \
+		-H "Accept: application/json" \
+		-X POST -d @- | python -mjson.tool) <<-EOF
+		{
+		    "entities": [
+		        {
+		            "type": "region",
+		            "isPattern": "true",
+		            "id": ".*"
+		        }
+		    ],
+		    "attributes": [
+		        "sanity_status"
+		    ],
+		    "reference": "$CALLBACK",
+		    "duration": "P99Y",
+		    "notifyConditions": [
+		        {
+		            "type": "ONCHANGE",
+		            "condValues": [
+		                "$TRIGGER"
+		            ]
+		        }
+		    ],
+		    "throttling": "PT5S"
+		}
+	EOF
+done

--- a/dashboard/lib/app.js
+++ b/dashboard/lib/app.js
@@ -260,9 +260,13 @@ app.use(config.webContext, stylus.middleware(
 
 app.use(session({secret: config.secret}));
 
-// trace all requests
+// trace all requests and include transaction id (if not present)
 app.use(function (req, res, next) {
-    logger.debug({op: 'app#use'}, '%s %s %s', req.method, req.url, req.path);
+    var txidHeader = constants.TRANSACTION_ID_HEADER.toLowerCase(),
+        txid = req.headers[txidHeader] || cuid(),
+        context = {trans: txid, op: 'app#use'};
+    logger.debug(context, '%s %s', req.method, req.url);
+    req.headers[txidHeader] = txid;
     next();
 });
 

--- a/dashboard/lib/app.js
+++ b/dashboard/lib/app.js
@@ -44,26 +44,30 @@ var app = express();
 
 logger.info('Running app in web context: %s', config.webContext);
 
+
 /**
- * base web context in url
+ * Base web context in URL
  * @type {string}
  */
 app.base = config.webContext;
 
+
 /**
- * web context
+ * Web context
  * @type {string}
  */
 app.locals.webContext = config.webContext;
+
+
 /**
- * contain title of web page
+ * Title of web page
  * @type {string}
  */
 app.locals.title = 'Sanity check status';
 
 
 /**
- * compile stylus css on runtime
+ * Compile Stylus CSS on runtime
  * @param {String} str
  * @param {String} path
  * @return {*|Function}
@@ -76,51 +80,49 @@ function compile(str, path) {
                 return new stylus.nodes.Literal('url("' + config.webContext + 'images/logo.png")');
         });
 }
+
+
 /**
- * called when /contextbroker post
+ * Called when POST on either `CONTEXT_SANITY_STATUS_VALUE` or `CONTEXT_SANITY_STATUS_CHANGE`
  * @param {*} req
  * @param {*} res
  */
-function postContextbroker(req, res) {
+function postContextBroker(req, res) {
 
     var txid = req.headers[constants.TRANSACTION_ID_HEADER.toLowerCase()] || cuid(),
-        context = {trans: txid, op: 'app#contextbroker'};
+        context = {trans: txid, op: 'app#contextbroker'},
+        mailman = subscribe;
 
     try {
-        var region = cbroker.changeReceived(txid, req),
+        var region = cbroker.getEntity(txid, req),
             notifyExclude = [ constants.GLOBAL_STATUS_OTHER ];
 
-        logger.info(context, 'status change notification received from contextbroker for region: %s', region.node);
+        logger.info(context, 'Received sanity_status notification from Context Broker for region "%s"', region.node);
         res.status(200).end();
 
         if (notifyExclude.indexOf(region.status) === -1) {
-            subscribe.notify(region, function (err) {
+            var recipient = (req.path.match('/' + constants.CONTEXT_SANITY_STATUS_CHANGE + '$')) ? mailman : monasca;
+            recipient.notify(region, function (err) {
                 if (err) {
-                    logger.error(context, 'post to mailing list failed: %s', err);
+                    logger.error(context, 'Notification to %s failed: %s', recipient.notify.destination, err);
                 } else {
-                    logger.info(context, 'post to mailing list succeeded');
-                }
-            });
-            monasca.notify(region, function (err) {
-                if (err) {
-                    logger.error(context, 'post to Monasca failed: %s', err);
-                } else {
-                    logger.info(context, 'post to Monasca succeeded');
+                    logger.info(context, 'Notification to %s succeeded', recipient.notify.destination);
                 }
             });
         } else {
-            logger.info(context, 'notifications not sent because region status %s is excluded', region.status);
+            logger.info(context, 'Discarded sanity_status notification (status %s is excluded)', region.status);
         }
 
     } catch (ex) {
-        logger.error(context, 'error in contextbroker notification: %s', ex);
+        logger.error(context, 'Processing of Context Broker notification failed: %s', ex);
         res.status(400).send({ error: 'bad request! ' + ex });
     }
 
 }
 
+
 /**
- * called when /logout get
+ * Called when GET on `CONTEXT_LOGOUT`
  * @param {*} req
  * @param {*} res
  */
@@ -137,7 +139,6 @@ function getLogout(req, res) {
 
 
 /**
- *
  * @param {*} response
  * @param {*} req
  * @param {*} res
@@ -156,8 +157,9 @@ function oauthGetCallback(response, req, res) {
     res.redirect(config.webContext);
 }
 
+
 /**
- * called when /signin get
+ * Called when GET on `CONTEXT_SIGNIN`
  * @param {*} req
  * @param {*} res
  * @param {*} oauth2
@@ -172,17 +174,16 @@ function getSignin(req, res, oauth2) {
         res.redirect(path);
         // If auth_token is stored in a session cookie it sends a button to get user info
     } else {
-
         oauth2.get(config.idm.url + '/user/', req.session.accessToken, function (e, response) {
             oauthGetCallback(response, req, res);
-
         });
 
     }
 }
 
+
 /**
- * check access token
+ * Check access token
  * @param {*} req
  * @param {*} res
  * @param {function} next
@@ -191,40 +192,39 @@ function getSignin(req, res, oauth2) {
 function checkToken(req, res, next, debugMessage) {
     logger.debug(debugMessage);
     if (req.session.accessToken) {
-
         next();
     } else {
         common.notAuthorized(req, res);
     }
 }
 
+
 /**
- *
  * @param {Object} results
  * @param {*} req
  * @param {*} res
  * @param {*} oauth2
  */
-
 function getOAuthAccessTokenCallback(results, req, res, oauth2) {
     logger.debug({op: 'app#get login'}, 'get access token:' + results);
 
-        if (results !== undefined) {
+    if (results !== undefined) {
 
-            // Stores the accessToken in a session cookie
-            /*jshint camelcase: false */
-            req.session.accessToken = results.access_token;
+        // Stores the accessToken in a session cookie
+        /*jshint camelcase: false */
+        req.session.accessToken = results.access_token;
 
-            logger.debug({op: 'app#get login'}, 'accessToken: ' + results.access_token);
+        logger.debug({op: 'app#get login'}, 'accessToken: ' + results.access_token);
 
-            oauth2.get(config.idm.url + '/user/', results.access_token, function (e, response) {
-                oauthGetCallback(response, req, res);
-            });
-        } else {
-            res.redirect(config.webContext);
+        oauth2.get(config.idm.url + '/user/', results.access_token, function (e, response) {
+            oauthGetCallback(response, req, res);
+        });
+    } else {
+        res.redirect(config.webContext);
 
-        }
+    }
 }
+
 
 /**
  * Handles requests from IDM with the access code
@@ -238,9 +238,7 @@ function getLogin(req, res, oauth2) {
 
     // Using the access code goes again to the IDM to obtain the accessToken
     oauth2.getOAuthAccessToken(req.query.code, function (e, results) {
-
         getOAuthAccessTokenCallback(results, req, res, oauth2);
-
     });
 }
 
@@ -276,24 +274,23 @@ app.use(cookieParser());
 app.use(config.webContext, express.static(path.join(__dirname, 'public')));
 
 
-app.use(config.webContext + 'refresh', function (req, res, next) {
-    checkToken(req, res, next, 'Accessing to refresh');
+app.use(config.webContext + constants.CONTEXT_REFRESH, function (req, res, next) {
+    checkToken(req, res, next, 'Accessing to /' + constants.CONTEXT_REFRESH);
 }, refresh);
 
-app.use(config.webContext + 'subscribe', function (req, res, next) {
-    checkToken(req, res, next, 'Accessing to subscribe');
 
+app.use(config.webContext + constants.CONTEXT_SUBSCRIBE, function (req, res, next) {
+    checkToken(req, res, next, 'Accessing to /' + constants.CONTEXT_SUBSCRIBE);
 }, subscribe);
 
-app.use(config.webContext + 'unsubscribe', function (req, res, next) {
-    checkToken(req, res, next, 'Accessing to unSubscribe');
 
+app.use(config.webContext + constants.CONTEXT_UNSUBSCRIBE, function (req, res, next) {
+    checkToken(req, res, next, 'Accessing to /' + constants.CONTEXT_UNSUBSCRIBE);
 }, unsubscribe);
 
 
 app.use(config.webContext, index);
 
-//configure login with oAuth
 
 // Creates oauth library object with the config data
 var oa = new OAuth2(config.idm.clientId,
@@ -304,39 +301,42 @@ var oa = new OAuth2(config.idm.clientId,
     config.idm.callbackURL);
 
 
-
-app.get(config.webContext + 'signin', function (req, res) {
+app.get(config.webContext + constants.CONTEXT_SIGNIN, function (req, res) {
     getSignin(req, res, oa);
 });
 
 
-app.get(config.webContext + 'login', function (req, res) {
-
-  getLogin(req, res, oa);
-
+app.get(config.webContext + constants.CONTEXT_LOGIN, function (req, res) {
+    getLogin(req, res, oa);
 });
 
-// listen request from contextbroker changes
-app.post(config.webContext + 'contextbroker', function (req, res) {
-   postContextbroker(req, res);
+
+// Change sanity_status notifications from Context Broker
+app.post(config.webContext + constants.CONTEXT_SANITY_STATUS_CHANGE, function (req, res) {
+    postContextBroker(req, res);
+});
+
+
+// Value sanity_status notifications from Context Broker
+app.post(config.webContext + constants.CONTEXT_SANITY_STATUS_VALUE, function (req, res) {
+    postContextBroker(req, res);
 });
 
 
 // Redirection to IDM authentication portal
-app.get(config.webContext + 'auth', function (req, res) {
+app.get(config.webContext + constants.CONTEXT_AUTH, function (req, res) {
     var path = oa.getAuthorizeUrl();
     res.redirect(path);
 });
 
+
 // Handles logout requests to remove accessToken from the session cookie
-app.get(config.webContext + 'logout', function (req, res) {
-
+app.get(config.webContext + constants.CONTEXT_LOGOUT, function (req, res) {
     getLogout(req, res);
-
 });
 
 
-// catch 404 and forward to error handler
+// Catch 404 and forward to error handler
 app.use(function (req, res) {
     var err = new Error('Not Found');
     err.status = 404;
@@ -345,14 +345,11 @@ app.use(function (req, res) {
         error: err,
         timestamp: req.session.titleTimestamp
     });
-
 });
 
 
-// error handlers
-
-// production error handler
-// no stacktraces leaked to user
+// Error handlers
+// Production error handler (no stacktraces leaked to user)
 app.use(function (err, req, res) {
     res.status(err.status || 500);
     res.render('error', {
@@ -366,9 +363,8 @@ app.use(function (err, req, res) {
 /** @export */
 module.exports = app;
 
-
 /** @export */
-module.exports.postContextbroker = postContextbroker;
+module.exports.postContextBroker = postContextBroker;
 
 /** @export */
 module.exports.getLogout = getLogout;

--- a/dashboard/lib/constants.js
+++ b/dashboard/lib/constants.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Telefónica I+D
+ * Copyright 2015-2016 Telefónica I+D
  * All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
@@ -31,3 +31,30 @@ module.exports.GLOBAL_STATUS_OTHER = 'N/A';
 
 /** @export */
 module.exports.TRANSACTION_ID_HEADER = 'txid';
+
+/** @export */
+module.exports.CONTEXT_AUTH = 'auth';
+
+/** @export */
+module.exports.CONTEXT_SIGNIN = 'signin';
+
+/** @export */
+module.exports.CONTEXT_LOGIN = 'login';
+
+/** @export */
+module.exports.CONTEXT_LOGOUT = 'logout';
+
+/** @export */
+module.exports.CONTEXT_REFRESH = 'refresh';
+
+/** @export */
+module.exports.CONTEXT_SUBSCRIBE = 'subscribe';
+
+/** @export */
+module.exports.CONTEXT_UNSUBSCRIBE = 'unsubscribe';
+
+/** @export */
+module.exports.CONTEXT_SANITY_STATUS_VALUE = 'sanity_status';
+
+/** @export */
+module.exports.CONTEXT_SANITY_STATUS_CHANGE = 'change_sanity_status';

--- a/dashboard/lib/monasca.js
+++ b/dashboard/lib/monasca.js
@@ -98,7 +98,7 @@ monasca.withAuthToken = function (callback) {
 
 /**
  * @function notify
- * Notify Monasca for a change in region
+ * Notify Monasca for new sanity_status value in a region
  * @param {Object} region
  * @param {function} notifyCallback
  */
@@ -163,6 +163,10 @@ monasca.notify = function (region, notifyCallback) {
         }
     });
 };
+
+
+/** Name of notify destination as an attribute */
+monasca.notify.destination = 'Monasca';
 
 
 /** @export */

--- a/dashboard/lib/routes/cbroker.js
+++ b/dashboard/lib/routes/cbroker.js
@@ -79,6 +79,7 @@ function parseRegions(txid, entities) {
         }
     });
 
+    logger.debug(context, 'Result: %j', result);
     return result;
 }
 
@@ -167,6 +168,11 @@ function retrieveAllRegions(txid, callback) {
  * @return {Object}
  */
 function getEntity(txid, req) {
+    var context = {trans: txid, op: 'getEntity'};
+    if (typeof req.body !== 'string') {
+        logger.warn(context, 'Non-string request body');
+        req.body = JSON.stringify(req.body);
+    }
     var result = parseRegions(txid, JSON.parse(req.body));
     return result[0];
 }

--- a/dashboard/lib/routes/cbroker.js
+++ b/dashboard/lib/routes/cbroker.js
@@ -161,12 +161,12 @@ function retrieveAllRegions(txid, callback) {
 
 
 /**
- * invoked when change is received from context broker
+ * Return the entity involved in a Context Broker notification
  * @param {string} txid
  * @param {*} req
  * @return {Object}
  */
-function changeReceived(txid, req) {
+function getEntity(txid, req) {
     var result = parseRegions(txid, JSON.parse(req.body));
     return result[0];
 }
@@ -179,4 +179,4 @@ module.exports.retrieveAllRegions = retrieveAllRegions;
 module.exports.parseRegions = parseRegions;
 
 /** @export */
-module.exports.changeReceived = changeReceived;
+module.exports.getEntity = getEntity;

--- a/dashboard/lib/routes/subscribe.js
+++ b/dashboard/lib/routes/subscribe.js
@@ -26,7 +26,7 @@ var express = require('express'),
 
 
 /**
- * router get subscribe
+ * Called by router when GET
  * @param {Object} req
  * @param {Object} res
  */
@@ -93,7 +93,6 @@ function isSubscribed(user, region, isSubscribedCallback) {
         method: 'GET'
     };
 
-
     function isMail(value) {
         return value === user;
     }
@@ -122,8 +121,9 @@ function isSubscribed(user, region, isSubscribedCallback) {
 
         });
     });
+
     mailmainRequest.on('error', function (e) {
-        logger.error({op: 'subscribe#isSubscribed'},'Error in connection with mailman: ' + e);
+        logger.error({op: 'subscribe#isSubscribed'}, 'Error in connection with mailman: ' + e);
         region.subscribed = false;
         isSubscribedCallback();
     });
@@ -131,8 +131,8 @@ function isSubscribed(user, region, isSubscribedCallback) {
     mailmainRequest.end();
 }
 
+
 /**
- *
  * @param {Object} user
  * @param {[]} regions
  * @param {callback} callback
@@ -142,12 +142,10 @@ function searchSubscription(user, regions, callback) {
     logger.debug('searchSubscription');
     var finished = _.after(regions.length, callback);
     regions.map(function (region) {
-
-
         isSubscribed(user, region, finished);
-
     });
 }
+
 
 /**
  * notify mailing list for a change in region
@@ -195,6 +193,7 @@ function notify(region, notifyCallback) {
 
         });
     });
+
     mailmanRequest.on('error', function (e) {
         logger.error('Error in connection with mailman: ' + e);
         notifyCallback(e);
@@ -205,20 +204,24 @@ function notify(region, notifyCallback) {
 }
 
 
-/* GET /subcribe: send PUT to mailman*/
+/** Name of notify destination as an attribute */
+notify.destination = 'mailing list';
+
+
 router.get('/', getSubscribe);
-
-
 
 /** @export */
 module.exports = router;
 
 /** @export */
 module.exports.getSubscribe = getSubscribe;
+
 /** @export */
 module.exports.isSubscribed = isSubscribed;
+
 /** @export */
 module.exports.searchSubscription = searchSubscription;
+
 /** @export */
 module.exports.notify = notify;
 

--- a/dashboard/lib/routes/subscribe.js
+++ b/dashboard/lib/routes/subscribe.js
@@ -36,14 +36,13 @@ function getSubscribe(req, res) {
 
     var userinfo = req.session.user;
 
-    logger.info({op: 'subscribe#get'}, 'subscribe to region: ' + region + ' userinfo:' + userinfo);
+    logger.info({op: 'subscribe#get'}, 'Subscribe to region: %s userinfo: %s', region, userinfo);
 
     var payloadString = 'address=' + userinfo.email;
 
     var headers = {
         'Content-Type': 'application/x-www-form-urlencoded',
         'Content-Length': payloadString.length
-
     };
 
     var options = {
@@ -69,7 +68,7 @@ function getSubscribe(req, res) {
         });
     });
     mailmainRequest.on('error', function (e) {
-        logger.error('Error in connection with mailman: ' + e);
+        logger.error('Error in connection with mailman: %s', e);
         res.redirect(config.webContext);
     });
 
@@ -123,7 +122,7 @@ function isSubscribed(user, region, isSubscribedCallback) {
     });
 
     mailmainRequest.on('error', function (e) {
-        logger.error({op: 'subscribe#isSubscribed'}, 'Error in connection with mailman: ' + e);
+        logger.error({op: 'subscribe#isSubscribed'}, 'Error in connection with mailman: %s', e);
         region.subscribed = false;
         isSubscribedCallback();
     });
@@ -195,7 +194,7 @@ function notify(region, notifyCallback) {
     });
 
     mailmanRequest.on('error', function (e) {
-        logger.error('Error in connection with mailman: ' + e);
+        logger.error('Error in connection with mailman: %s', e);
         notifyCallback(e);
     });
 

--- a/dashboard/lib/routes/unsubscribe.js
+++ b/dashboard/lib/routes/unsubscribe.js
@@ -25,7 +25,7 @@ var express = require('express'),
 
 
 /**
- * router get unSubscribe
+ * Called by router when GET
  * @param {Object} req
  * @param {Object} res
  */
@@ -67,6 +67,7 @@ function getUnSubscribe(req, res) {
             res.redirect(config.webContext);
         });
     });
+
     mailmainRequest.on('error', function (e) {
         logger.error('Error in connection with mailman: ' + e);
         res.redirect(config.webContext);
@@ -79,7 +80,6 @@ function getUnSubscribe(req, res) {
 }
 
 
-/* GET /unsubcribe: send DELETE to mailman*/
 router.get('/', getUnSubscribe);
 
 /** @export */

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -1,11 +1,11 @@
 {
   "name": "fihealth_dashboard",
   "description": "FIHealth Dashboard",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "product": {
     "name": "fiware-health",
     "area": "iotplatform",
-    "release": "5.3.1"
+    "release": "5.3.2"
   },
   "repository": {
     "type": "git",

--- a/dashboard/test/unit/test_app.js
+++ b/dashboard/test/unit/test_app.js
@@ -102,7 +102,7 @@ suite('app', function () {
         monascaNotifyStub.restore();
         getEntityStub.restore();
         assert(res.status.withArgs(200).calledOnce);
-        assert(mailmanNotifyStub.calledOnce)
+        assert(mailmanNotifyStub.calledOnce);
         assert(monascaNotifyStub.notCalled);
     });
 
@@ -130,7 +130,7 @@ suite('app', function () {
         monascaNotifyStub.restore();
         getEntityStub.restore();
         assert(res.status.withArgs(200).calledOnce);
-        assert(mailmanNotifyStub.notCalled)
+        assert(mailmanNotifyStub.notCalled);
         assert(monascaNotifyStub.calledOnce);
     });
 

--- a/dashboard/test/unit/test_app.js
+++ b/dashboard/test/unit/test_app.js
@@ -53,7 +53,7 @@ suite('app', function () {
     });
 
     test('should_have_some_methods', function () {
-        assert.equal(app.postContextbroker.name, 'postContextbroker');
+        assert.equal(app.postContextBroker.name, 'postContextBroker');
         assert.equal(app.getLogout.name, 'getLogout');
     });
 
@@ -66,19 +66,19 @@ suite('app', function () {
         res.status = sinon.stub();
         res.status.withArgs(400).returns(res);
 
-        var cbrokerStub = sinon.stub(cbroker, 'changeReceived');
-        cbrokerStub.throws();
+        var getEntityStub = sinon.stub(cbroker, 'getEntity');
+        getEntityStub.throws();
 
         //when
-        app.postContextbroker(req, res);
+        app.postContextBroker(req, res);
 
         //then
-        cbrokerStub.restore();
+        getEntityStub.restore();
         assert(res.status.withArgs(400).calledOnce);
         assert(res.send.calledOnce);
     });
 
-    test('should_return_200_in_contextbroker_post', function () {
+    test('should_only_notify_mailman_in_contextbroker_post_for_sanity_status_change', function () {
         //given
         var req = this.request,
             res = this.response;
@@ -86,26 +86,55 @@ suite('app', function () {
         res.end = sinon.spy();
         res.status = sinon.stub();
         res.status.withArgs(200).returns(res);
+        req.path = '/' + constants.CONTEXT_SANITY_STATUS_CHANGE;
 
-        var subscribeStub = sinon.stub(subscribe, 'notify'),
-            monascaStub = sinon.stub(monasca, 'notify'),
-            cbrokerStub = sinon.stub(cbroker, 'changeReceived', function () {
+        var mailmanNotifyStub = sinon.stub(subscribe, 'notify'),
+            monascaNotifyStub = sinon.stub(monasca, 'notify'),
+            getEntityStub = sinon.stub(cbroker, 'getEntity', function () {
                 return {'node': 'Region1', 'status': 'OK', 'timestamp': ''};
             });
 
         //when
-        app.postContextbroker(req, res);
+        app.postContextBroker(req, res);
 
         //then
-        subscribeStub.restore();
-        monascaStub.restore();
-        cbrokerStub.restore();
+        mailmanNotifyStub.restore();
+        monascaNotifyStub.restore();
+        getEntityStub.restore();
         assert(res.status.withArgs(200).calledOnce);
-        assert(subscribeStub.calledOnce);
-        assert(monascaStub.calledOnce);
+        assert(mailmanNotifyStub.calledOnce)
+        assert(monascaNotifyStub.notCalled);
     });
 
-    test('should_return_200_in_contextbroker_post_when_region_status_excluded', function () {
+    test('should_only_notify_monasca_in_contextbroker_post_for_sanity_status_value', function () {
+        //given
+        var req = this.request,
+            res = this.response;
+
+        res.end = sinon.spy();
+        res.status = sinon.stub();
+        res.status.withArgs(200).returns(res);
+        req.path = '/' + constants.CONTEXT_SANITY_STATUS_VALUE;
+
+        var mailmanNotifyStub = sinon.stub(subscribe, 'notify'),
+            monascaNotifyStub = sinon.stub(monasca, 'notify'),
+            getEntityStub = sinon.stub(cbroker, 'getEntity', function () {
+                return {'node': 'Region1', 'status': 'OK', 'timestamp': ''};
+            });
+
+        //when
+        app.postContextBroker(req, res);
+
+        //then
+        mailmanNotifyStub.restore();
+        monascaNotifyStub.restore();
+        getEntityStub.restore();
+        assert(res.status.withArgs(200).calledOnce);
+        assert(mailmanNotifyStub.notCalled)
+        assert(monascaNotifyStub.calledOnce);
+    });
+
+    test('should_not_notify_at_all_in_contextbroker_post_when_region_status_excluded', function () {
         //given
         var req = this.request,
             res = this.response;
@@ -114,22 +143,22 @@ suite('app', function () {
         res.status = sinon.stub();
         res.status.withArgs(200).returns(res);
 
-        var subscribeStub = sinon.stub(subscribe, 'notify'),
-            monascaStub = sinon.stub(monasca, 'notify'),
-            cbrokerStub = sinon.stub(cbroker, 'changeReceived', function () {
+        var mailmanNotifyStub = sinon.stub(subscribe, 'notify'),
+            monascaNotifyStub = sinon.stub(monasca, 'notify'),
+            getEntityStub = sinon.stub(cbroker, 'getEntity', function () {
                 return {'node': 'Region1', 'status': constants.GLOBAL_STATUS_OTHER, 'timestamp': ''};
             });
 
         //when
-        app.postContextbroker(req, res);
+        app.postContextBroker(req, res);
 
         //then
-        subscribeStub.restore();
-        monascaStub.restore();
-        cbrokerStub.restore();
+        mailmanNotifyStub.restore();
+        monascaNotifyStub.restore();
+        getEntityStub.restore();
         assert(res.status.withArgs(200).calledOnce);
-        assert(subscribeStub.notCalled);
-        assert(monascaStub.notCalled);
+        assert(mailmanNotifyStub.notCalled);
+        assert(monascaNotifyStub.notCalled);
     });
 
     test('should_close_session_with_get_logout', function () {
@@ -202,7 +231,6 @@ suite('app', function () {
         //then
         assert(next.calledOnce);
     });
-
 
     test('should_check_token_with_invalid_token', function () {
         //given

--- a/dashboard/test/unit/test_cbroker.js
+++ b/dashboard/test/unit/test_cbroker.js
@@ -139,7 +139,7 @@ suite('cbroker', function () {
             };
 
         //when
-        var result = cbroker.changeReceived(this.txid, req);
+        var result = cbroker.getEntity(this.txid, req);
 
         //then
         assert.deepEqual(expected, result);

--- a/dashboard/test/unit/test_monasca.js
+++ b/dashboard/test/unit/test_monasca.js
@@ -67,7 +67,7 @@ suite('monasca', function () {
             return request;
         });
 
-        var keystoneStub = sinon.stub(monasca, 'withAuthToken', function (callback) {
+        var keystoneStub = sinon.stub(monasca, 'withAuthToken', function (context, callback) {
             callback('TOKEN');
         });
 
@@ -103,7 +103,7 @@ suite('monasca', function () {
             return request;
         });
 
-        var keystoneStub = sinon.stub(monasca, 'withAuthToken', function (callback) {
+        var keystoneStub = sinon.stub(monasca, 'withAuthToken', function (context, callback) {
             callback('TOKEN');
         });
 
@@ -179,7 +179,7 @@ suite('monasca', function () {
 
     test('should_return_error_if_no_auth_token_obtained', function (done) {
         //given
-        var keystoneStub = sinon.stub(monasca, 'withAuthToken', function (callback) {
+        var keystoneStub = sinon.stub(monasca, 'withAuthToken', function (context, callback) {
             callback();
         });
 


### PR DESCRIPTION
#### Reviewers

@jesuspg 
#### Description

Despite notifications to Mailman, which should only occur when `sanity_status` value changes, the notifications to Monasca API should be sent no matter the value changes or remains the same, in order to have full historical data.

A second ContextBroker ONCHANGE subscription is created, this time bound to the `sanity_check_timestamp` attribute. Therefore, on every new Sanity Checks execution, this attribute will be updated and ContextBroker will notify Dashboard, which in turn will publish into Monasca API.
#### Testing

Verified in FIWARE Lab for Spain2.
