### PR TITLE
Add transaction_id for traceability

### DIFF
--- a/dashboard/lib/app.js
+++ b/dashboard/lib/app.js
@@ -95,7 +95,7 @@ function postContextBroker(req, res) {
 
     try {
         var region = cbroker.getEntity(req, context),
-            notifyExclude = [ constants.GLOBAL_STATUS_OTHER],
+            notifyExclude = [ constants.GLOBAL_STATUS_OTHER ],
             notifyType = (recipient === mailman) ? 'sanity status change' : 'sanity check execution',
             txid = context.trans;
 

--- a/dashboard/lib/constants.js
+++ b/dashboard/lib/constants.js
@@ -33,6 +33,9 @@ module.exports.GLOBAL_STATUS_OTHER = 'N/A';
 module.exports.TRANSACTION_ID_HEADER = 'txid';
 
 /** @export */
+module.exports.TRANSACTION_ID_NGSI_ATTR = 'sanity_build_number';
+
+/** @export */
 module.exports.CONTEXT_AUTH = 'auth';
 
 /** @export */

--- a/dashboard/lib/monasca.js
+++ b/dashboard/lib/monasca.js
@@ -100,12 +100,13 @@ monasca.withAuthToken = function (context, callback) {
 /**
  * @function notify
  * Notify Monasca for new sanity_status value in a region
+ * @param {string} txid
  * @param {Object} region
  * @param {function} notifyCallback
  */
-monasca.notify = function (region, notifyCallback) {
+monasca.notify = function (txid, region, notifyCallback) {
     var regionName = region.node,
-        context = {op: 'monasca#notify'};
+        context = {trans: txid, op: 'monasca#notify'};
 
     logger.info(context, 'Notify sanity_status for region "%s"', regionName);
     this.withAuthToken(context, function (authToken) {

--- a/dashboard/lib/routes/subscribe.js
+++ b/dashboard/lib/routes/subscribe.js
@@ -150,15 +150,17 @@ function searchSubscription(user, callback) {
 
 /**
  * notify mailing list for a change in region
+ * @param {string} txid
  * @param {Object} region
  * @param {function} notifyCallback
  */
-function notify(region, notifyCallback) {
+function notify(txid, region, notifyCallback) {
 
     var regionName = region.node,
-        regionStatus = region.status;
+        regionStatus = region.status,
+        context = {trans: txid, op: 'subscribe#notify'};
 
-    logger.info({op: 'subscribe#notify'}, 'notify change in region: ' + regionName);
+    logger.info(context, 'notify change in region "%s"', regionName);
 
     var payloadString = 'name_from= fi-health sanity&';
     payloadString += 'email_from=' + config.mailman.emailFrom + '&';
@@ -188,15 +190,14 @@ function notify(region, notifyCallback) {
             responseString += data;
         });
         mailmanResponse.on('end', function () {
-            logger.info('response mailman: region: %s, code: %s, message: %s', regionName, mailmanResponse.statusCode,
-                mailmanResponse.statusMessage);
+            logger.info(context, 'response mailman: region: %s, code: %s, message: %s', regionName,
+                mailmanResponse.statusCode, mailmanResponse.statusMessage);
             notifyCallback();
-
         });
     });
 
     mailmanRequest.on('error', function (e) {
-        logger.error('Error in connection with mailman: %s', e);
+        logger.error(context, 'Error in connection with mailman: %s', e);
         notifyCallback(e);
     });
 

--- a/dashboard/test/unit/test_app.js
+++ b/dashboard/test/unit/test_app.js
@@ -70,6 +70,7 @@ suite('app', function () {
         res.send = sinon.spy();
         res.status = sinon.stub();
         res.status.withArgs(400).returns(res);
+        req.path = '/';
 
         var getEntityStub = sinon.stub(cbroker, 'getEntity');
         getEntityStub.throws();
@@ -147,6 +148,7 @@ suite('app', function () {
         res.end = sinon.spy();
         res.status = sinon.stub();
         res.status.withArgs(200).returns(res);
+        req.path = '/' + constants.CONTEXT_SANITY_STATUS_CHANGE;
 
         var mailmanNotifyStub = sinon.stub(subscribe, 'notify'),
             monascaNotifyStub = sinon.stub(monasca, 'notify'),

--- a/dashboard/test/unit/test_cbroker.js
+++ b/dashboard/test/unit/test_cbroker.js
@@ -119,10 +119,12 @@ suite('cbroker', function () {
 
     setup(function () {
         this.txid = cuid();
+        this.context = {trans: this.txid, op: 'test'};
     });
 
     teardown(function () {
         delete this.txid;
+        delete this.context;
     });
 
     test('should_have_a_retrieveAllRegions_method', function () {
@@ -150,11 +152,12 @@ suite('cbroker', function () {
         var data = this.sampleDataNotifyContext,
             expected = this.parsedRegionsNotifyContext[0],
             req = {
+                headers: [],
                 body: data
             };
 
         //when
-        var result = cbroker.getEntity(this.txid, req);
+        var result = cbroker.getEntity(req, this.context);
 
         //then
         assert.deepEqual(expected, result);

--- a/dashboard/test/unit/test_monasca.js
+++ b/dashboard/test/unit/test_monasca.js
@@ -21,6 +21,7 @@ var assert = require('assert'),
     init = require('./init'),
     sinon = require('sinon'),
     http = require('http'),
+    cuid = require('cuid'),
     EventEmitter = require('events').EventEmitter,
     logger = require('../../lib/logger'),
     monasca = require('../../lib/monasca');
@@ -44,6 +45,14 @@ suite('monasca', function () {
 
     suiteTeardown(function () {
         logger.stream = stream;
+    });
+
+    setup(function () {
+        this.txid = cuid();
+    });
+
+    teardown(function () {
+        delete this.txid;
     });
 
     test('should_notify_to_monasca_api', function () {
@@ -74,7 +83,7 @@ suite('monasca', function () {
         var notifyError;
 
         //when
-        monasca.notify(region, function (err) {
+        monasca.notify(this.txid, region, function (err) {
             notifyError = err;
         });
 
@@ -108,7 +117,7 @@ suite('monasca', function () {
         });
 
         //when
-        monasca.notify(region, function (err) {
+        monasca.notify(this.txid, region, function (err) {
             http.request.restore();
             keystoneStub.restore();
             assert(err instanceof Error);
@@ -142,7 +151,7 @@ suite('monasca', function () {
         });
 
         //when
-        monasca.notify(region, function (err) {
+        monasca.notify(this.txid, region, function (err) {
             http.request.restore();
             assert(err instanceof Error);
             done();
@@ -168,7 +177,7 @@ suite('monasca', function () {
         });
 
         //when
-        monasca.notify(region, function (err) {
+        monasca.notify(this.txid, region, function (err) {
             http.request.restore();
             assert(err instanceof Error);
             done();
@@ -184,7 +193,7 @@ suite('monasca', function () {
         });
 
         //when
-        monasca.notify(region, function (err) {
+        monasca.notify(this.txid, region, function (err) {
             keystoneStub.restore();
             assert(err instanceof Error);
             done();

--- a/dashboard/test/unit/test_subscribe.js
+++ b/dashboard/test/unit/test_subscribe.js
@@ -21,6 +21,7 @@ var assert = require('assert'),
     sinon = require('sinon'),
     EventEmitter = require('events').EventEmitter,
     http = require('http'),
+    cuid = require('cuid'),
     init = require('./init'),
     logger = require('../../lib/logger'),
     subscribe = require('../../lib/routes/subscribe'),
@@ -262,7 +263,8 @@ suite('subscribe', function () {
         });
 
         //when
-        subscribe.notify(region, function() {
+        var txid = cuid();
+        subscribe.notify(txid, region, function() {
         });
 
         //then

--- a/fiware-region-sanity-tests/doc/publish_status_and_test_data.rst
+++ b/fiware-region-sanity-tests/doc/publish_status_and_test_data.rst
@@ -13,11 +13,13 @@ __ `Context Broker - Context subscriptions`_
 To do that, a request to the `NGSI Adapter`_ component must be issued. The name
 of the probe originating source data will be ``sanity_tests``::
 
-    $ curl "{adapter_endpoint}/sanity_tests?id={myregion}&type=region" -s -S \
-    --header 'Content-Type: text/plain' -X POST -d @test_results.txt
+    $ curl "{adapter_endpoint}/sanity_tests?id={myregion}&type=region" \
+    --header "Content-Type: text/plain" --header "txId: $BUILD_NUMBER" \
+    -X POST -s -S -d @test_results.txt
 
 Please note that the invocation to NGSI Adapter, once summary report has been
 generated, is **only** automated when running the Sanity Checks within Jenkins.
+Job's build number is used as transaction identifier for traceability.
 
 As a prerequisite, custom parser ``resources/parsers/sanity_tests.js`` (provided
 as part of this component) has to be installed together with the rest of parsers
@@ -25,14 +27,14 @@ bundled in NGSI Adapter package.
 
 Such parser will extract NGSI attributes from the summary report and then invoke
 Context Broker to update region context. In this process the **Sanity Status**
-is calculated depending the results of individual tests
+is calculated depending the results of individual tests.
 
 Here is an example of the generated ``test_results.txt`` for an specific region
 (*my_region*) is the following:
 
 ::
 
-    [Tests: 28, Errors: 0, Failures: 0, Skipped: 0]
+    [Tests: 28, Errors: 0, Failures: 0, Skipped: 0] | BUILD_NUMBER=12345
 
     REGION GLOBAL STATUS
 
@@ -77,16 +79,6 @@ Here is an example of the generated ``test_results.txt`` for an specific region
       OK	 test_images_not_empty
 
 
-Elapsed execution time of Sanity Checks
----------------------------------------
-
-Apart from the context attributes described above, when Sanity Checks
-have been executed from Jenkins, a new attribute is updated in the
-context information of the region: the elapsed time of the execution
-``sanity_check_elapsed_time``. This attribute will measure the time in
-milliseconds or 'N/A' if Sanity tests have not finished yet.
-
-
 Sanity Check Status and Test Execution Status
 ---------------------------------------------
 
@@ -105,12 +97,12 @@ have been *PASSED*. If some of these *key test cases* are failed but these ones
 are defined in the second property, the status of the region will
 be **Partial OK**.
 
-The target of the *Sanity Check Status* is to be used as value in the
+The aim of the *Sanity Check Status* is to be used as the value for the
 **sanity_check_status** context attribute to be sent to Context Broker
-by NGSI-Adapter. Other context attributes are sent to Context Broker,
-one for each executed sanity test with their result (**sanity_check_***).
+by NGSI Adapter. Additional context attributes are sent to Context Broker,
+one for each individual sanity test (named **sanity_check_***).
 
-So that, we have two type of statuses:
+Therefore, we have two type of statuses:
 
 - **Sanity Check Status**. The responsible for calculating this value is the
   custom parser for the NGSI Adapter aforementioned, whose input is the summary
@@ -134,9 +126,9 @@ So that, we have two type of statuses:
   +---------------+---------------------------------------------+
 
 
-- **Test status**. The ``commons/result_analyzer.py`` script only generates
-  the ``test_results.txt`` report with the list of executed test cases and their
-  results, and also 'mark' the region considering the *key_test_cases*
+- **Test status**. The ``commons/result_analyzer.py`` script generates the
+  ``test_results.txt`` report with the list of executed test cases and their
+  results, and also 'marks' the region considering the *key_test_cases*
   and *opt_test_cases*. Result of tests could be:
 
   +-------------+---------------------------------------------+
@@ -152,6 +144,16 @@ So that, we have two type of statuses:
   |             | assertions has failed or an exception       |
   |             | has been raised                             |
   +-------------+---------------------------------------------+
+
+
+Timestamp and elapsed execution time of Sanity Checks
+-----------------------------------------------------
+
+Apart from the context attributes described above, when Sanity Checks
+have been executed from Jenkins a new attribute ``sanity_check_elapsed_time``
+is updated in the context information of the region: the elapsed time of the
+execution in milliseconds. And the parser in NGSI Adapter will also add
+the ``sanity_check_timestamp`` attribute.
 
 
 .. REFERENCES

--- a/fiware-region-sanity-tests/resources/parsers/sanity_tests.js
+++ b/fiware-region-sanity-tests/resources/parsers/sanity_tests.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Telefónica I+D
+ * Copyright 2015-2016 Telefónica I+D
  * All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
@@ -23,6 +23,8 @@
  *
  * - sanity_status = global status of the region
  * - sanity_{test} = status of each individual {test}
+ * - sanity_build_number = the build number in Jenkins (optional)
+ * - sanity_check_timestamp = timestamp of last change of sanity_* attributes
  *
  * @module sanity_tests
  * @see https://github.com/telefonicaid/fiware-health/blob/master/fiware-region-sanity-tests
@@ -68,7 +70,7 @@ parser.parseRequest = function(request) {
  * @returns {Object} Context attributes.
  *
  * Sample report with GLOBAL_STATUS_NOT_OK: <code>
- * [Tests: 22, Errors: 0, Failures: 8, Skipped: 0]
+ * [Tests: 22, Errors: 0, Failures: 8, Skipped: 0] | BUILD_NUMBER=12345
  *
  * REGION GLOBAL STATUS
  *
@@ -108,7 +110,7 @@ parser.parseRequest = function(request) {
  * </code>
  *
  * Sample report with GLOBAL_STATUS_PARTIAL_OK: <code>
- * [Tests: 22, Errors: 0, Failures: 2, Skipped: 0]
+ * [Tests: 22, Errors: 0, Failures: 2, Skipped: 0] | BUILD_NUMBER=12345
  *
  * REGION GLOBAL STATUS
  *
@@ -163,13 +165,19 @@ parser.getContextAttrs = function(probeEntityData) {
     var empty_line = '\n\n',
         components = probeEntityData.status.split(empty_line),
         key_status_line = components[2].split('\n')[1],
-        opt_status_line = components[3].split('\n')[1];
+        opt_status_line = components[3].split('\n')[1],
+        build_number = components[0].split(' | BUILD_NUMBER=')[1];
 
     // Region global status
     if (key_status_line.match(/>>\s+\b\w+\b/)) {
         attrs['sanity_status'] = GLOBAL_STATUS_OK;
     } else if (opt_status_line.match(/>>\s+\b\w+\b/)) {
         attrs['sanity_status'] = GLOBAL_STATUS_PARTIAL_OK;
+    }
+
+    // Jenkins build number
+    if (build_number) {
+        attrs['sanity_build_number'] = build_number;
     }
 
     // Timestamp for tests results

--- a/fiware-region-sanity-tests/sanity_checks
+++ b/fiware-region-sanity-tests/sanity_checks
@@ -30,6 +30,7 @@
 #     -s, --settings=FILE		sanity checks configuration file
 #     -o, --output-name=NAME		basename for generated report files
 #     -t, --template-name=NAME		filename of the HTML report template
+#     -b, --build-number=NUMBER		optional Jenkins build number
 #     -e, --phonehome-endpoint=URL	optional PhoneHome service endpoint
 #     -l, --os-auth-url=URL		optional OpenStack auth_url (see below)
 #     -u, --os-username=STRING		optional OpenStack username
@@ -75,6 +76,7 @@ OPTS=`tr -d '\n ' <<END
       s(settings):
       o(output-name):
       t(template-name):
+      b(build-number):
       e(phonehome-endpoint):
       l(os-auth-url):
       u(os-username):
@@ -90,10 +92,11 @@ END`
 NOSEOPTS="--config=etc/nose.cfg"
 OUTPUT_NOVA_CONSOLE_NAME=test_novaconsole
 
-# Command line options (default values / environment variables)
+# Command line options (some default values taken from environment)
 OUTPUT_NAME=test_results
 TEMPLATE_NAME=test_report_template.html
 SANITY_CHECKS_SETTINGS=${SANITY_CHECKS_SETTINGS:-etc/settings.json}
+BUILD_NUMBER=
 
 # Export environment variables required by the tests
 export SANITY_CHECKS_SETTINGS
@@ -122,6 +125,7 @@ case $OPT in
 'v')	NOSEOPTS="$NOSEOPTS --logging-level=DEBUG";;
 'e')	TEST_PHONEHOME_ENDPOINT=$OPTARG;;
 't')	TEMPLATE_NAME=$OPTARG;;
+'b')	BUILD_NUMBER=$OPTARG;;
 'o')	OUTPUT_NAME=$OPTARG;;
 'l')	OS_AUTH_URL=$OPTARG;;
 'u')	OS_USERNAME=$OPTARG;;
@@ -185,6 +189,6 @@ echo "Result code=$?"
 # Summary report
 if [ -s $OUTPUT_NAME.xml ]; then
 	printf "Generating summary report... "
-	commons/results_analyzer.py $OUTPUT_NAME.xml > $OUTPUT_NAME.txt
+	commons/results_analyzer.py $OUTPUT_NAME.xml $BUILD_NUMBER > $OUTPUT_NAME.txt
 	printf "%s\n" $OUTPUT_NAME.txt
 fi


### PR DESCRIPTION
#### Reviewers

@jesuspg @flopezag 
#### Description

In order to increase traceability, the Jenkins build number originating a particular run of Sanity Checks is propagated as transaction_id across the different components involved.
#### Testing

All tests passed
